### PR TITLE
Add IPTV news channel playlists for VLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,60 @@
-## Welcome to GitHub Pages
+# IPTV News Channels for VLC
 
-You can use the [editor on GitHub](https://github.com/vvashista/hello-world/edit/master/README.md) to maintain and preview the content for your website in Markdown files.
+Curated **English** and **Hindi** news channel playlists for an IPTV-like live TV experience in [VLC Media Player](https://www.videolan.org/vlc/).
 
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
+## Playlists
 
-### Markdown
+| Playlist | File | Description |
+|----------|------|-------------|
+| English News | [`iptv/english-news.m3u`](iptv/english-news.m3u) | International & Indian English news |
+| Hindi News | [`iptv/hindi-news.m3u`](iptv/hindi-news.m3u) | Major Hindi news channels |
+| All News | [`iptv/all-news.m3u`](iptv/all-news.m3u) | Combined English + Hindi |
 
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
+## Quick start
 
-```markdown
-Syntax highlighted code block
+### Option 1: VLC GUI
 
-# Header 1
-## Header 2
-### Header 3
+1. Install VLC from [videolan.org](https://www.videolan.org/vlc/)
+2. **Media → Open File** and select a playlist (e.g. `iptv/hindi-news.m3u`)
+3. **View → Playlist** (`Ctrl+L` / `Cmd+L`) to browse channels
+4. Use **Up/Down** or **PgUp/PgDn** to switch channels
 
-- Bulleted
-- List
+### Option 2: Command line
 
-1. Numbered
-2. List
-
-**Bold** and _Italic_ and `Code` text
-
-[Link](url) and ![Image](src)
+```bash
+./scripts/watch-news.sh              # English news (default)
+./scripts/watch-news.sh hindi        # Hindi news
+./scripts/watch-news.sh all          # All news channels
+./scripts/watch-news.sh hindi --channel 3
+./scripts/watch-news.sh --list       # List all channels
 ```
 
-For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
+## Included channels
 
-### Jekyll Themes
+### English news
 
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/vvashista/hello-world/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
+- Al Jazeera English, BBC News, France 24 English, DW English
+- Sky News, Reuters, Euronews, CGTN, TRT World, NHK World
+- NDTV 24x7, WION, Times Now, Republic TV, Mirror Now
+- ABC News Australia, CBS News 24/7, Fox News, Bloomberg TV, CNBC
 
-### Support or Contact
+### Hindi news
 
-Having trouble with Pages? Check out our [documentation](https://help.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.
+- Aaj Tak, ABP News, NDTV India, DD News, Zee News
+- Republic Bharat, TV9 Bharatvarsh, News18 India, News Nation
+- India TV, Times Now Navbharat, Bharat Samachar, Good News Today
+- Sudarshan News, News 24, Sansad TV
+
+## Refresh playlists
+
+Streams are pulled from the community-maintained [iptv-org/iptv](https://github.com/iptv-org/iptv) project. To update local playlists:
+
+```bash
+python3 scripts/build-playlists.py
+```
+
+## Notes
+
+- These are **free-to-air public streams** — availability varies by region and may change over time.
+- Some channels may be geo-blocked or marked `[Not 24/7]`.
+- VLC groups channels under **English News** and **Hindi News** in the playlist sidebar.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>IPTV News Channels for VLC</title>
+  <style>
+    :root {
+      --bg: #0f1419;
+      --card: #1a2332;
+      --accent: #ff6b35;
+      --text: #e8edf4;
+      --muted: #8b9cb3;
+      --border: #2a3548;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Segoe UI", system-ui, sans-serif;
+      background: linear-gradient(160deg, #0f1419 0%, #1a2332 100%);
+      color: var(--text);
+      min-height: 100vh;
+    }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
+    h1 { font-size: 2rem; margin: 0 0 0.5rem; }
+    .subtitle { color: var(--muted); margin-bottom: 2rem; }
+    .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.25rem;
+    }
+    .card h2 { margin: 0 0 0.75rem; font-size: 1.15rem; }
+    .card p { color: var(--muted); font-size: 0.95rem; line-height: 1.5; }
+    a.btn {
+      display: inline-block;
+      margin-top: 0.75rem;
+      padding: 0.55rem 1rem;
+      background: var(--accent);
+      color: #111;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+    }
+    a.btn.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
+    code, pre {
+      background: #0b1018;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+    code { padding: 0.15rem 0.4rem; }
+    pre { padding: 1rem; overflow-x: auto; }
+    ol { padding-left: 1.2rem; line-height: 1.7; }
+    .channels { columns: 2; gap: 1.5rem; font-size: 0.92rem; color: var(--muted); }
+    @media (max-width: 600px) { .channels { columns: 1; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>IPTV News for VLC</h1>
+    <p class="subtitle">Curated English and Hindi news channel playlists — open in VLC for an IPTV-style live TV experience.</p>
+
+    <div class="grid">
+      <div class="card">
+        <h2>English News</h2>
+        <p>International and Indian English news channels including BBC, Al Jazeera, NDTV 24x7, WION, and more.</p>
+        <a class="btn" href="iptv/english-news.m3u">Download playlist</a>
+      </div>
+      <div class="card">
+        <h2>Hindi News</h2>
+        <p>Major Hindi news channels including Aaj Tak, ABP News, NDTV India, Zee News, Republic Bharat, and more.</p>
+        <a class="btn" href="iptv/hindi-news.m3u">Download playlist</a>
+      </div>
+      <div class="card">
+        <h2>All News</h2>
+        <p>Combined playlist with both English and Hindi news channels in one file.</p>
+        <a class="btn" href="iptv/all-news.m3u">Download playlist</a>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top: 1.5rem;">
+      <h2>Quick start with VLC</h2>
+      <ol>
+        <li>Install <a href="https://www.videolan.org/vlc/">VLC Media Player</a>.</li>
+        <li>Download a playlist above, or clone this repo.</li>
+        <li>In VLC: <strong>Media → Open File</strong> and select the <code>.m3u</code> file.</li>
+        <li>Open the playlist panel (<strong>View → Playlist</strong> or <code>Ctrl+L</code>) to browse channels.</li>
+        <li>Use <strong>Up/Down</strong> or <strong>PgUp/PgDn</strong> to switch channels like live TV.</li>
+      </ol>
+      <p>From the command line:</p>
+      <pre>git clone &lt;this-repo&gt;
+cd hello-world
+./scripts/watch-news.sh hindi
+./scripts/watch-news.sh english --channel 2</pre>
+    </div>
+
+    <div class="card" style="margin-top: 1rem;">
+      <h2>Included channels (sample)</h2>
+      <div class="channels">
+        <strong>English</strong>
+        <ul>
+          <li>Al Jazeera English</li>
+          <li>BBC News</li>
+          <li>France 24 English</li>
+          <li>DW English</li>
+          <li>Reuters</li>
+          <li>NDTV 24x7</li>
+          <li>WION</li>
+          <li>Times Now</li>
+          <li>Republic TV</li>
+          <li>CBS News 24/7</li>
+        </ul>
+        <strong>Hindi</strong>
+        <ul>
+          <li>Aaj Tak</li>
+          <li>ABP News</li>
+          <li>NDTV India</li>
+          <li>DD News</li>
+          <li>Zee News</li>
+          <li>Republic Bharat</li>
+          <li>TV9 Bharatvarsh</li>
+          <li>News18 India</li>
+          <li>India TV</li>
+          <li>Sansad TV</li>
+        </ul>
+      </div>
+    </div>
+
+    <p style="margin-top: 1.5rem; color: var(--muted); font-size: 0.85rem;">
+      Streams are sourced from publicly available free-to-air feeds indexed by
+      <a href="https://github.com/iptv-org/iptv">iptv-org/iptv</a>.
+      Availability may vary by region and over time. Run <code>python3 scripts/build-playlists.py</code> to refresh.
+    </p>
+  </div>
+</body>
+</html>

--- a/iptv/all-news.m3u
+++ b/iptv/all-news.m3u
@@ -1,0 +1,76 @@
+#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
+#PLAYLIST:Hindi News Channels
+#EXTINF:-1 tvg-id="AajTak.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png" group-title="Hindi News",Aaj Tak HD (1080p)
+https://feeds.intoday.in/aajtak/api/aajtakhd/master.m3u8
+#EXTINF:-1 tvg-id="ABPNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540" group-title="Hindi News",ABP News (1080p)
+https://d1rc86nwwc9fag.cloudfront.net/vglive-sk-472500/abpnews/master.m3u8
+#EXTINF:-1 tvg-id="NDTVIndia.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",NDTV India (720p)
+http://103.213.31.109:90/StarUtsavMovies/playlist.m3u8
+#EXTINF:-1 tvg-id="DDNews.in@HD" tvg-logo="https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png" group-title="Hindi News",DD News HD (1080p)
+https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/0811cd8c37ca4c409d5385a6cd2fa18b/index.m3u8
+#EXTINF:-1 tvg-id="ZeeNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540" group-title="Hindi News",Zee News (1080p)
+https://dknttpxmr0dwf.cloudfront.net/index_57.m3u8
+#EXTINF:-1 tvg-id="RepublicBharat.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540" group-title="Hindi News",Republic Bharat (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicBharat.m3u8
+#EXTINF:-1 tvg-id="TV9Bharatvarsh.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png" group-title="Hindi News",TV9 Bharatvarsh (720p)
+https://dyjmyiv3bp2ez.cloudfront.net/pub-iotv9hinjzgtpe/liveabr/playlist.m3u8
+#EXTINF:-1 tvg-id="News18India.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",News18 India (1080p)
+https://n18syndication.akamaized.net/bpk-tv/News18_India_NW18_MOB/output01/master.m3u8
+#EXTINF:-1 tvg-id="NewsNation.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png" group-title="Hindi News",News Nation (1080p)
+https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/6cd2f649739a45ca9de1daf81cc7d0f2/index.m3u8
+#EXTINF:-1 tvg-id="IndiaTV.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png" group-title="Hindi News",India TV (720p)
+https://pl-indiatvnews.akamaized.net/out/v1/db79179b608641ceaa5a4d0dd0dca8da/index.m3u8
+#EXTINF:-1 tvg-id="TimesNowNavbharat.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png" group-title="Hindi News",Times Now Navbharat (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/TimesNowNavbharat.m3u8
+#EXTINF:-1 tvg-id="BharatSamachar.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png" group-title="Hindi News",Bharat Samachar (576p)
+https://trs1.aynaott.com/BharatSamachar/index.m3u8
+#EXTINF:-1 tvg-id="GoodNewsToday.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png" group-title="Hindi News",Good News Today (720p)
+https://aajtaklive.vgcdn.net/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/3196cced-ce29-4219-9809-f07ccdaa02b9/vglive-sk-848805/master.m3u8
+#EXTINF:-1 tvg-id="SudarshanNews.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png" group-title="Hindi News",Sudarshan News (1080p)
+https://ott.livelegitpro.in/sudarshannews/sudarshannews/tracks-v1/index.fmp4.m3u8
+#EXTINF:-1 tvg-id="News24.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540" group-title="Hindi News",News 24 (720p)
+https://vidcdn.vidgyor.com/news24-origin/liveabr/playlist.m3u8
+#EXTINF:-1 tvg-id="SansadTV1.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png" group-title="Hindi News",Sansad TV 1 HD (1080p)
+https://d2lk5u59tns74c.cloudfront.net/out/v1/fff8f20221d5456e8922e689d71dedc3/index.m3u8
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="English News",Al Jazeera English (1080p)
+https://live-hls-apps-aje-fa.getaj.net/AJE/index.m3u8
+#EXTINF:-1 tvg-id="France24.fr@English" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png" group-title="English News",France 24 English (1080p)
+https://live.france24.com/hls/live/2037218-b/F24_EN_HI_HLS/master_5000.m3u8
+#EXTINF:-1 tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="English News",DW English (1080p)
+https://amg01644-amg01644c1-amgplt0343.playout.now3.amagi.tv/ts-eu-w1-n2/playlist/amg01644-amg01644c1-amgplt0343/playlist.m3u8
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png" group-title="English News",BBC News (1080p) [Geo-blocked]
+https://pb-iiczlgfysam0q.akamaized.net/v1/amcnetworks_bbcnews_1/samsungheadend_us/latest/main/hls/playlist.m3u8
+#EXTINF:-1 tvg-id="SkyNews.ie@SD" tvg-logo="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png" group-title="English News",Sky News (576p)
+http://41.205.77.102/SKYNEWS/index.m3u8
+#EXTINF:-1 tvg-id="ReutersTV.us@SD" tvg-logo="https://i.imgur.com/6eQ2nCJ.png" group-title="English News",Reuters (1080p)
+https://amg00453-reuters-amg00453c1-rakuten-uk-2110.playouts.now.amagi.tv/playlist/amg00453-reuters-reuters-rakutenuk/playlist.m3u8
+#EXTINF:-1 tvg-id="NDTV24x7.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png" group-title="English News",NDTV 24x7 (720p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/NDTV24x7.m3u8
+#EXTINF:-1 tvg-id="ABCNews.au@Sydney" tvg-logo="https://i.imgur.com/BrW7gk8.png" group-title="English News",ABC News (720p)
+https://abc-news-dmd-streams-1.akamaized.net/out/v1/701126012d044971b3fa89406a440133/index.m3u8
+#EXTINF:-1 tvg-id="CBSNews247.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png" group-title="English News",CBS News 24/7 (720p)
+https://jmp2.uk/plu-6350fdd266e9ea0007bedec5.m3u8
+#EXTINF:-1 tvg-id="FoxNewsChannel.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png" group-title="English News",Fox News Channel (720p)
+http://138.121.15.230:9002/FOX-NEWS/index.m3u8
+#EXTINF:-1 tvg-id="EuronewsEnglish.fr@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png" group-title="English News",Euronews English (720p)
+https://jmp2.uk/plu-61de96114757070008d33cae.m3u8
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png" group-title="English News",CGTN (1080p)
+https://amg00405-rakutentv-cgtn-rakuten-i9tar.amagi.tv/master.m3u8
+#EXTINF:-1 tvg-id="TRTWorld.tr@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png" group-title="English News",TRT World (1080p) [Not 24/7]
+https://tv-trtworld.medya.trt.com.tr/master.m3u8
+#EXTINF:-1 tvg-id="WION.in@SD" tvg-logo="https://i.imgur.com/Wc5Z3iS.png" group-title="English News",WION (1080p)
+http://vg-zeefta.akamaized.net/ptnr-yupptv/title-wion/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/20c3c0d9-0256-43fe-bca6-70fdd490b957/main.m3u8
+#EXTINF:-1 tvg-id="TimesNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png" http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0" group-title="English News",Times Now News (720p)
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0
+https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/times-now-news/master.m3u8?ads.vf=yxbqJWPCXd4
+#EXTINF:-1 tvg-id="RepublicTV.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540" group-title="English News",Republic TV (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicTV.m3u8
+#EXTINF:-1 tvg-id="MirrorNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png" http-referrer="https://www.timesnownews.com/" group-title="English News",Mirror Now (720p)
+#EXTVLCOPT:http-referrer=https://www.timesnownews.com/
+https://dai.google.com/linear/hls/event/ClPOullTQky5vGPf7fMZ8g/master.m3u8
+#EXTINF:-1 tvg-id="BloombergTV.us@US" tvg-logo="https://i.imgur.com/OuogLHx.png" group-title="English News",Bloomberg TV (1080p)
+http://23.237.104.106:8080/USA_BLOOMBERG/index.m3u8
+#EXTINF:-1 tvg-id="CNBCUK.uk@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png" group-title="English News",CNBC (1080p)
+https://amg01079-nbcuuk-amg01079c2-samsung-gb-1258.playouts.now.amagi.tv/playlist.m3u8
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png" group-title="English News",NHK World-Japan (1080p)
+https://masterpl.hls.nhkworld.jp/hls/w/live/smarttv.m3u8

--- a/iptv/english-news.m3u
+++ b/iptv/english-news.m3u
@@ -1,0 +1,44 @@
+#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
+#PLAYLIST:English News Channels
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="English News",Al Jazeera English (1080p)
+https://live-hls-apps-aje-fa.getaj.net/AJE/index.m3u8
+#EXTINF:-1 tvg-id="France24.fr@English" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png" group-title="English News",France 24 English (1080p)
+https://live.france24.com/hls/live/2037218-b/F24_EN_HI_HLS/master_5000.m3u8
+#EXTINF:-1 tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="English News",DW English (1080p)
+https://amg01644-amg01644c1-amgplt0343.playout.now3.amagi.tv/ts-eu-w1-n2/playlist/amg01644-amg01644c1-amgplt0343/playlist.m3u8
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png" group-title="English News",BBC News (1080p) [Geo-blocked]
+https://pb-iiczlgfysam0q.akamaized.net/v1/amcnetworks_bbcnews_1/samsungheadend_us/latest/main/hls/playlist.m3u8
+#EXTINF:-1 tvg-id="SkyNews.ie@SD" tvg-logo="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png" group-title="English News",Sky News (576p)
+http://41.205.77.102/SKYNEWS/index.m3u8
+#EXTINF:-1 tvg-id="ReutersTV.us@SD" tvg-logo="https://i.imgur.com/6eQ2nCJ.png" group-title="English News",Reuters (1080p)
+https://amg00453-reuters-amg00453c1-rakuten-uk-2110.playouts.now.amagi.tv/playlist/amg00453-reuters-reuters-rakutenuk/playlist.m3u8
+#EXTINF:-1 tvg-id="NDTV24x7.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png" group-title="English News",NDTV 24x7 (720p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/NDTV24x7.m3u8
+#EXTINF:-1 tvg-id="ABCNews.au@Sydney" tvg-logo="https://i.imgur.com/BrW7gk8.png" group-title="English News",ABC News (720p)
+https://abc-news-dmd-streams-1.akamaized.net/out/v1/701126012d044971b3fa89406a440133/index.m3u8
+#EXTINF:-1 tvg-id="CBSNews247.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png" group-title="English News",CBS News 24/7 (720p)
+https://jmp2.uk/plu-6350fdd266e9ea0007bedec5.m3u8
+#EXTINF:-1 tvg-id="FoxNewsChannel.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png" group-title="English News",Fox News Channel (720p)
+http://138.121.15.230:9002/FOX-NEWS/index.m3u8
+#EXTINF:-1 tvg-id="EuronewsEnglish.fr@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png" group-title="English News",Euronews English (720p)
+https://jmp2.uk/plu-61de96114757070008d33cae.m3u8
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png" group-title="English News",CGTN (1080p)
+https://amg00405-rakutentv-cgtn-rakuten-i9tar.amagi.tv/master.m3u8
+#EXTINF:-1 tvg-id="TRTWorld.tr@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png" group-title="English News",TRT World (1080p) [Not 24/7]
+https://tv-trtworld.medya.trt.com.tr/master.m3u8
+#EXTINF:-1 tvg-id="WION.in@SD" tvg-logo="https://i.imgur.com/Wc5Z3iS.png" group-title="English News",WION (1080p)
+http://vg-zeefta.akamaized.net/ptnr-yupptv/title-wion/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/20c3c0d9-0256-43fe-bca6-70fdd490b957/main.m3u8
+#EXTINF:-1 tvg-id="TimesNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png" http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0" group-title="English News",Times Now News (720p)
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0
+https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/times-now-news/master.m3u8?ads.vf=yxbqJWPCXd4
+#EXTINF:-1 tvg-id="RepublicTV.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540" group-title="English News",Republic TV (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicTV.m3u8
+#EXTINF:-1 tvg-id="MirrorNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png" http-referrer="https://www.timesnownews.com/" group-title="English News",Mirror Now (720p)
+#EXTVLCOPT:http-referrer=https://www.timesnownews.com/
+https://dai.google.com/linear/hls/event/ClPOullTQky5vGPf7fMZ8g/master.m3u8
+#EXTINF:-1 tvg-id="BloombergTV.us@US" tvg-logo="https://i.imgur.com/OuogLHx.png" group-title="English News",Bloomberg TV (1080p)
+http://23.237.104.106:8080/USA_BLOOMBERG/index.m3u8
+#EXTINF:-1 tvg-id="CNBCUK.uk@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png" group-title="English News",CNBC (1080p)
+https://amg01079-nbcuuk-amg01079c2-samsung-gb-1258.playouts.now.amagi.tv/playlist.m3u8
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png" group-title="English News",NHK World-Japan (1080p)
+https://masterpl.hls.nhkworld.jp/hls/w/live/smarttv.m3u8

--- a/iptv/hindi-news.m3u
+++ b/iptv/hindi-news.m3u
@@ -1,0 +1,34 @@
+#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
+#PLAYLIST:Hindi News Channels
+#EXTINF:-1 tvg-id="AajTak.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png" group-title="Hindi News",Aaj Tak HD (1080p)
+https://feeds.intoday.in/aajtak/api/aajtakhd/master.m3u8
+#EXTINF:-1 tvg-id="ABPNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540" group-title="Hindi News",ABP News (1080p)
+https://d1rc86nwwc9fag.cloudfront.net/vglive-sk-472500/abpnews/master.m3u8
+#EXTINF:-1 tvg-id="NDTVIndia.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",NDTV India (720p)
+http://103.213.31.109:90/StarUtsavMovies/playlist.m3u8
+#EXTINF:-1 tvg-id="DDNews.in@HD" tvg-logo="https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png" group-title="Hindi News",DD News HD (1080p)
+https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/0811cd8c37ca4c409d5385a6cd2fa18b/index.m3u8
+#EXTINF:-1 tvg-id="ZeeNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540" group-title="Hindi News",Zee News (1080p)
+https://dknttpxmr0dwf.cloudfront.net/index_57.m3u8
+#EXTINF:-1 tvg-id="RepublicBharat.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540" group-title="Hindi News",Republic Bharat (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicBharat.m3u8
+#EXTINF:-1 tvg-id="TV9Bharatvarsh.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png" group-title="Hindi News",TV9 Bharatvarsh (720p)
+https://dyjmyiv3bp2ez.cloudfront.net/pub-iotv9hinjzgtpe/liveabr/playlist.m3u8
+#EXTINF:-1 tvg-id="News18India.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",News18 India (1080p)
+https://n18syndication.akamaized.net/bpk-tv/News18_India_NW18_MOB/output01/master.m3u8
+#EXTINF:-1 tvg-id="NewsNation.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png" group-title="Hindi News",News Nation (1080p)
+https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/6cd2f649739a45ca9de1daf81cc7d0f2/index.m3u8
+#EXTINF:-1 tvg-id="IndiaTV.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png" group-title="Hindi News",India TV (720p)
+https://pl-indiatvnews.akamaized.net/out/v1/db79179b608641ceaa5a4d0dd0dca8da/index.m3u8
+#EXTINF:-1 tvg-id="TimesNowNavbharat.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png" group-title="Hindi News",Times Now Navbharat (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/TimesNowNavbharat.m3u8
+#EXTINF:-1 tvg-id="BharatSamachar.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png" group-title="Hindi News",Bharat Samachar (576p)
+https://trs1.aynaott.com/BharatSamachar/index.m3u8
+#EXTINF:-1 tvg-id="GoodNewsToday.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png" group-title="Hindi News",Good News Today (720p)
+https://aajtaklive.vgcdn.net/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/3196cced-ce29-4219-9809-f07ccdaa02b9/vglive-sk-848805/master.m3u8
+#EXTINF:-1 tvg-id="SudarshanNews.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png" group-title="Hindi News",Sudarshan News (1080p)
+https://ott.livelegitpro.in/sudarshannews/sudarshannews/tracks-v1/index.fmp4.m3u8
+#EXTINF:-1 tvg-id="News24.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540" group-title="Hindi News",News 24 (720p)
+https://vidcdn.vidgyor.com/news24-origin/liveabr/playlist.m3u8
+#EXTINF:-1 tvg-id="SansadTV1.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png" group-title="Hindi News",Sansad TV 1 HD (1080p)
+https://d2lk5u59tns74c.cloudfront.net/out/v1/fff8f20221d5456e8922e689d71dedc3/index.m3u8

--- a/scripts/build-playlists.py
+++ b/scripts/build-playlists.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Build curated Hindi and English news M3U playlists from iptv-org sources."""
+
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+IPTV_ORG_HIN = "https://iptv-org.github.io/iptv/languages/hin.m3u"
+IPTV_ORG_ENG = "https://iptv-org.github.io/iptv/languages/eng.m3u"
+
+# Curated channels by tvg-id (preferred) with display name fallback patterns.
+HINDI_CHANNELS = [
+    ("AajTak.in@HD", "Aaj Tak"),
+    ("ABPNews.in@SD", "ABP News"),
+    ("NDTVIndia.in@SD", "NDTV India"),
+    ("DDNews.in@HD", "DD News"),
+    ("ZeeNews.in@SD", "Zee News"),
+    ("RepublicBharat.in@SD", "Republic Bharat"),
+    ("TV9Bharatvarsh.in@SD", "TV9 Bharatvarsh"),
+    ("News18India.in@SD", "News18 India"),
+    ("NewsNation.in@SD", "News Nation"),
+    ("IndiaTV.in@SD", "India TV"),
+    ("TimesNowNavbharat.in@SD", "Times Now Navbharat"),
+    ("BharatSamachar.in@SD", "Bharat Samachar"),
+    ("GoodNewsToday.in@SD", "Good News Today"),
+    ("SudarshanNews.in@SD", "Sudarshan News"),
+    ("News24.in@SD", "News 24"),
+    ("SansadTV1.in@HD", "Sansad TV"),
+]
+
+ENGLISH_CHANNELS = [
+    ("AlJazeera.qa@English", "Al Jazeera English"),
+    ("France24.fr@English", "France 24 English"),
+    ("DW.de@English", "DW English"),
+    ("BBCNews.uk@UK", "BBC News"),
+    ("BBCNews.uk@Europe", "BBC News"),
+    ("SkyNews.uk@SD", "Sky News"),
+    ("SkyNews.ie@SD", "Sky News"),
+    ("ReutersTV.us@SD", "Reuters"),
+    ("NDTV24x7.in@SD", "NDTV 24x7"),
+    ("ABCNews.au@Sydney", "ABC News Australia"),
+    ("CBSNews247.us@SD", "CBS News 24/7"),
+    ("FoxNewsChannel.us@SD", "Fox News"),
+    ("EuronewsEnglish.fr@SD", "Euronews English"),
+    ("CGTN.cn@SD", "CGTN"),
+    ("TRTWorld.tr@SD", "TRT World"),
+    ("WION.in@SD", "WION"),
+    ("TimesNow.in@SD", "Times Now"),
+    ("RepublicTV.in@SD", "Republic TV"),
+    ("MirrorNow.in@SD", "Mirror Now"),
+    ("BloombergTV.us@US", "Bloomberg TV"),
+    ("CNBCUK.uk@SD", "CNBC"),
+    ("NHKWorldJapan.jp@SD", "NHK World"),
+]
+
+
+def fetch_m3u(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=60) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def parse_m3u(content: str) -> list[dict]:
+    entries = []
+    lines = content.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.startswith("#EXTINF"):
+            i += 1
+            continue
+
+        info = line
+        extras = []
+        i += 1
+        while i < len(lines) and lines[i].startswith("#EXT"):
+            extras.append(lines[i])
+            i += 1
+
+        url = lines[i] if i < len(lines) and not lines[i].startswith("#") else ""
+        i += 1
+
+        tvg_id_match = re.search(r'tvg-id="([^"]+)"', info)
+        channel_name = info.rsplit(",", 1)[-1] if "," in info else ""
+        entries.append(
+            {
+                "tvg_id": tvg_id_match.group(1) if tvg_id_match else "",
+                "name": channel_name,
+                "info": info,
+                "extras": extras,
+                "url": url,
+            }
+        )
+    return entries
+
+
+def find_entry(entries: list[dict], tvg_id: str, label: str) -> dict | None:
+    for entry in entries:
+        if entry["tvg_id"] == tvg_id:
+            return entry
+    for entry in entries:
+        if label.lower() in entry["name"].lower() and "News" in entry["info"]:
+            return entry
+    return None
+
+
+def build_playlist(title: str, group: str, channel_specs: list[tuple[str, str]], entries: list[dict]) -> str:
+    lines = [
+        '#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"',
+        f"#PLAYLIST:{title}",
+    ]
+    seen_urls: set[str] = set()
+
+    for tvg_id, label in channel_specs:
+        entry = find_entry(entries, tvg_id, label)
+        if not entry or not entry["url"]:
+            print(f"  - missing: {label} ({tvg_id})", file=sys.stderr)
+            continue
+        if entry["url"] in seen_urls:
+            continue
+        seen_urls.add(entry["url"])
+
+        info = re.sub(r'group-title="[^"]*"', f'group-title="{group}"', entry["info"])
+        lines.append(info)
+        lines.extend(entry["extras"])
+        lines.append(entry["url"])
+        print(f"  + {label}: {entry['name']}", file=sys.stderr)
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    out_dir = root / "iptv"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("Fetching Hindi channels...", file=sys.stderr)
+    hin_entries = parse_m3u(fetch_m3u(IPTV_ORG_HIN))
+    print("Fetching English channels...", file=sys.stderr)
+
+    eng_entries = parse_m3u(fetch_m3u(IPTV_ORG_ENG))
+
+    print("\nHindi news:", file=sys.stderr)
+    hindi = build_playlist("Hindi News Channels", "Hindi News", HINDI_CHANNELS, hin_entries)
+
+    print("\nEnglish news:", file=sys.stderr)
+    english = build_playlist("English News Channels", "English News", ENGLISH_CHANNELS, eng_entries)
+
+    (out_dir / "hindi-news.m3u").write_text(hindi, encoding="utf-8")
+    (out_dir / "english-news.m3u").write_text(english, encoding="utf-8")
+
+    combined_lines = hindi.splitlines()[:2]
+    for block in (hindi, english):
+        for line in block.splitlines():
+            if line.startswith("#EXTINF") or line.startswith("#EXTVLCOPT") or (
+                line.startswith("http") and line.strip()
+            ):
+                if line not in combined_lines:
+                    combined_lines.append(line)
+
+    (out_dir / "all-news.m3u").write_text("\n".join(combined_lines) + "\n", encoding="utf-8")
+    print(f"\nWrote playlists to {out_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/watch-news.sh
+++ b/scripts/watch-news.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Launch VLC with IPTV news playlists for an IPTV-like channel browsing experience.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IPTV_DIR="$REPO_ROOT/iptv"
+
+usage() {
+  cat <<'EOF'
+Usage: watch-news.sh [english|hindi|all] [--channel N]
+
+Open curated news channel playlists in VLC.
+
+  english   English news channels (default)
+  hindi     Hindi news channels
+  all       Combined English + Hindi playlist
+
+Options:
+  --channel N   Start on channel number N (1-based)
+  --list        Print available playlists and exit
+  --help        Show this help
+
+Examples:
+  ./scripts/watch-news.sh
+  ./scripts/watch-news.sh hindi
+  ./scripts/watch-news.sh all --channel 3
+EOF
+}
+
+pick_vlc() {
+  if command -v cvlc >/dev/null 2>&1; then
+    echo "cvlc"
+  elif command -v vlc >/dev/null 2>&1; then
+    echo "vlc"
+  else
+    echo "VLC is not installed. Install it with:" >&2
+    echo "  Ubuntu/Debian: sudo apt install vlc" >&2
+    echo "  macOS:         brew install --cask vlc" >&2
+    echo "  Windows:       https://www.videolan.org/vlc/" >&2
+    exit 1
+  fi
+}
+
+playlist_for() {
+  case "$1" in
+    english) echo "$IPTV_DIR/english-news.m3u" ;;
+    hindi) echo "$IPTV_DIR/hindi-news.m3u" ;;
+    all) echo "$IPTV_DIR/all-news.m3u" ;;
+    *) echo "Unknown playlist: $1" >&2; usage; exit 1 ;;
+  esac
+}
+
+list_channels() {
+  local playlist="$1"
+  local n=0
+  while IFS= read -r line; do
+    if [[ "$line" == \#EXTINF* ]]; then
+      n=$((n + 1))
+      name="${line##*,}"
+      printf "%3d. %s\n" "$n" "$name"
+    fi
+  done < "$playlist"
+}
+
+main() {
+  local lang="english"
+  local channel=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      english|hindi|all) lang="$1" ;;
+      --channel) shift; channel="${1:-}" ;;
+      --list)
+        for kind in english hindi all; do
+          local_file="$(playlist_for "$kind")"
+          echo "== $kind ($local_file) =="
+          list_channels "$local_file"
+          echo
+        done
+        exit 0
+        ;;
+      --help|-h) usage; exit 0 ;;
+      *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+    shift
+  done
+
+  local playlist
+  playlist="$(playlist_for "$lang")"
+  if [[ ! -f "$playlist" ]]; then
+    echo "Playlist not found: $playlist" >&2
+    echo "Run: python3 scripts/build-playlists.py" >&2
+    exit 1
+  fi
+
+  local vlc
+  vlc="$(pick_vlc)"
+
+  echo "Opening $lang news playlist in VLC..."
+  echo "Playlist: $playlist"
+  echo
+  echo "IPTV tips in VLC:"
+  echo "  - View > Playlist (Ctrl+L) to browse channels"
+  echo "  - Use Up/Down or PgUp/PgDn to change channels"
+  echo "  - Channels are grouped under 'English News' / 'Hindi News'"
+  echo
+
+  if [[ -n "$channel" ]]; then
+    local url
+    url="$(awk -v n="$channel" '
+      /^#EXTINF/ { idx++ }
+      idx == n && /^https?:/ { print; exit }
+    ' "$playlist")"
+    if [[ -z "$url" ]]; then
+      echo "Channel $channel not found in playlist." >&2
+      exit 1
+    fi
+    exec "$vlc" "$url"
+  fi
+
+  exec "$vlc" "$playlist"
+}
+
+main "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an IPTV-style live news experience using VLC with curated **English** and **Hindi** news channel playlists.

## What's included

- **`iptv/english-news.m3u`** — 20 English news channels (Al Jazeera, BBC, NDTV 24x7, WION, Times Now, etc.)
- **`iptv/hindi-news.m3u`** — 16 Hindi news channels (Aaj Tak, ABP News, NDTV India, Zee News, Republic Bharat, etc.)
- **`iptv/all-news.m3u`** — Combined playlist
- **`scripts/watch-news.sh`** — One-command VLC launcher with channel listing
- **`scripts/build-playlists.py`** — Refresh playlists from [iptv-org/iptv](https://github.com/iptv-org/iptv)
- **`index.html`** — Landing page with download links and setup instructions
- **`README.md`** — Usage documentation

## How to use

```bash
./scripts/watch-news.sh hindi        # Hindi news
./scripts/watch-news.sh english      # English news
./scripts/watch-news.sh all          # All channels
./scripts/watch-news.sh --list       # List channels
```

Or open any `.m3u` file in VLC via **Media → Open File**, then browse channels in the playlist panel (`Ctrl+L`).

## Notes

- Streams are free-to-air public feeds; availability may vary by region.
- Some channels may be geo-blocked or intermittent.
- Run `python3 scripts/build-playlists.py` to refresh stream URLs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f49af-9dea-78d6-985b-834da5f75ab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f49af-9dea-78d6-985b-834da5f75ab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

