### PR TITLE
Add intuitive VLC news channel navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+iptv/.start-channel.m3u

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 iptv/.start-channel.m3u
+credentials/
+!credentials/.gitignore

--- a/README.md
+++ b/README.md
@@ -74,6 +74,40 @@ See [`iptv/channel-guide.txt`](iptv/channel-guide.txt) or the [web channel guide
 - India TV, Times Now Navbharat, Bharat Samachar, Good News Today
 - Sudarshan News, News 24, Sansad TV
 
+## Upload to Google Drive
+
+Google Drive requires a one-time credentials setup. After that, upload all playlists with:
+
+```bash
+pip install -r requirements-drive.txt
+export GOOGLE_DRIVE_FOLDER_ID="<your-folder-id>"
+export GOOGLE_APPLICATION_CREDENTIALS="credentials/service-account.json"
+python3 scripts/upload-to-drive.py
+```
+
+### Setup (service account — recommended)
+
+1. Open [Google Cloud Console](https://console.cloud.google.com/) → **APIs & Services** → enable **Google Drive API**
+2. **Credentials** → **Create credentials** → **Service account** → download JSON key
+3. Save the key as `credentials/service-account.json` (this path is gitignored)
+4. In [Google Drive](https://drive.google.com), create a folder (e.g. "IPTV News")
+5. Share that folder with the service account email from the JSON (`client_email`), as **Editor**
+6. Copy the folder ID from the URL: `https://drive.google.com/drive/folders/FOLDER_ID_HERE`
+7. Run the upload commands above
+
+### Alternative: OAuth sign-in
+
+1. Create an **OAuth Desktop** client in Google Cloud Console
+2. Download `credentials/oauth-client.json`
+3. Run:
+   ```bash
+   export GOOGLE_OAUTH_CLIENT_SECRET="credentials/oauth-client.json"
+   python3 scripts/upload-to-drive.py
+   ```
+4. Sign in via the browser when prompted (token saved to `credentials/drive-token.json`)
+
+Files uploaded by default: `hindi-news.m3u`, `english-news.m3u`, `all-news.m3u`, `channel-guide.txt`
+
 ## Refresh playlists
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,37 +1,60 @@
-## Welcome to GitHub Pages
+# IPTV News Channels for VLC
 
-You can use the [editor on GitHub](https://github.com/vvashista/hello-world/edit/master/README.md) to maintain and preview the content for your website in Markdown files.
+Curated **English** and **Hindi** news channel playlists for an IPTV-like live TV experience in [VLC Media Player](https://www.videolan.org/vlc/).
 
-Whenever you commit to this repository, GitHub Pages will run [Jekyll](https://jekyllrb.com/) to rebuild the pages in your site, from the content in your Markdown files.
+## Playlists
 
-### Markdown
+| Playlist | File | Description |
+|----------|------|-------------|
+| English News | [`iptv/english-news.m3u`](iptv/english-news.m3u) | International & Indian English news |
+| Hindi News | [`iptv/hindi-news.m3u`](iptv/hindi-news.m3u) | Major Hindi news channels |
+| All News | [`iptv/all-news.m3u`](iptv/all-news.m3u) | Combined English + Hindi |
 
-Markdown is a lightweight and easy-to-use syntax for styling your writing. It includes conventions for
+## Quick start
 
-```markdown
-Syntax highlighted code block
+### Option 1: VLC GUI
 
-# Header 1
-## Header 2
-### Header 3
+1. Install VLC from [videolan.org](https://www.videolan.org/vlc/)
+2. **Media → Open File** and select a playlist (e.g. `iptv/hindi-news.m3u`)
+3. **View → Playlist** (`Ctrl+L` / `Cmd+L`) to browse channels
+4. Use **Up/Down** or **PgUp/PgDn** to switch channels
 
-- Bulleted
-- List
+### Option 2: Command line
 
-1. Numbered
-2. List
-
-**Bold** and _Italic_ and `Code` text
-
-[Link](url) and ![Image](src)
+```bash
+./scripts/watch-news.sh              # English news (default)
+./scripts/watch-news.sh hindi        # Hindi news
+./scripts/watch-news.sh all          # All news channels
+./scripts/watch-news.sh hindi --channel 3
+./scripts/watch-news.sh --list       # List all channels
 ```
 
-For more details see [GitHub Flavored Markdown](https://guides.github.com/features/mastering-markdown/).
+## Included channels
 
-### Jekyll Themes
+### English news
 
-Your Pages site will use the layout and styles from the Jekyll theme you have selected in your [repository settings](https://github.com/vvashista/hello-world/settings). The name of this theme is saved in the Jekyll `_config.yml` configuration file.
+- Al Jazeera English, BBC News, France 24 English, DW English
+- Sky News, Reuters, Euronews, CGTN, TRT World, NHK World
+- NDTV 24x7, WION, Times Now, Republic TV, Mirror Now
+- ABC News Australia, CBS News 24/7, Fox News, Bloomberg TV, CNBC
 
-### Support or Contact
+### Hindi news
 
-Having trouble with Pages? Check out our [documentation](https://help.github.com/categories/github-pages-basics/) or [contact support](https://github.com/contact) and we’ll help you sort it out.
+- Aaj Tak, ABP News, NDTV India, DD News, Zee News
+- Republic Bharat, TV9 Bharatvarsh, News18 India, News Nation
+- India TV, Times Now Navbharat, Bharat Samachar, Good News Today
+- Sudarshan News, News 24, Sansad TV
+
+## Refresh playlists
+
+Streams are pulled from the community-maintained [iptv-org/iptv](https://github.com/iptv-org/iptv) project. To update local playlists:
+
+```bash
+python3 scripts/build-playlists.py
+```
+
+## Notes
+
+- These are **free-to-air public streams** — availability varies by region and may change over time.
+- Some channels may be geo-blocked or marked `[Not 24/7]`.
+- VLC groups channels under **English News** and **Hindi News** in the playlist sidebar.

--- a/README.md
+++ b/README.md
@@ -2,32 +2,61 @@
 
 Curated **English** and **Hindi** news channel playlists for an IPTV-like live TV experience in [VLC Media Player](https://www.videolan.org/vlc/).
 
+## Navigate channels
+
+### Interactive navigator (recommended)
+
+```bash
+./scripts/news-tv.sh
+```
+
+This opens a menu where you can:
+
+- Choose **Hindi**, **English**, or **All** news packs
+- Tune by **channel number** (`101`, `205`) or **name** (`aaj`, `bbc`)
+- Launch VLC with the full playlist and your pick loaded first
+
+Quick jumps:
+
+```bash
+./scripts/news-tv.sh --lang hindi --channel 101   # Aaj Tak
+./scripts/news-tv.sh --search bbc                 # BBC News
+./scripts/news-tv.sh --list                       # Print channel guide
+```
+
+### Channel numbers
+
+| Range | Language |
+|-------|----------|
+| 101–199 | Hindi news |
+| 201–299 | English news |
+
+See [`iptv/channel-guide.txt`](iptv/channel-guide.txt) or the [web channel guide](guide.html).
+
+### VLC controls while watching
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+L` | Open playlist sidebar (grouped by language) |
+| `PgUp` / `PgDn` | Previous / next channel |
+| `Up` / `Down` | Step through playlist |
+| `F` | Fullscreen |
+
 ## Playlists
 
 | Playlist | File | Description |
 |----------|------|-------------|
 | English News | [`iptv/english-news.m3u`](iptv/english-news.m3u) | International & Indian English news |
 | Hindi News | [`iptv/hindi-news.m3u`](iptv/hindi-news.m3u) | Major Hindi news channels |
-| All News | [`iptv/all-news.m3u`](iptv/all-news.m3u) | Combined English + Hindi |
+| All News | [`iptv/all-news.m3u`](iptv/all-news.m3u) | Combined, grouped with `#EXTGRP` |
 
-## Quick start
-
-### Option 1: VLC GUI
+## Quick start (manual)
 
 1. Install VLC from [videolan.org](https://www.videolan.org/vlc/)
-2. **Media → Open File** and select a playlist (e.g. `iptv/hindi-news.m3u`)
-3. **View → Playlist** (`Ctrl+L` / `Cmd+L`) to browse channels
-4. Use **Up/Down** or **PgUp/PgDn** to switch channels
+2. Run `./scripts/news-tv.sh` or open a playlist via **Media → Open File**
+3. Press `Ctrl+L` to browse grouped channels
 
-### Option 2: Command line
-
-```bash
-./scripts/watch-news.sh              # English news (default)
-./scripts/watch-news.sh hindi        # Hindi news
-./scripts/watch-news.sh all          # All news channels
-./scripts/watch-news.sh hindi --channel 3
-./scripts/watch-news.sh --list       # List all channels
-```
+`./scripts/watch-news.sh` is an alias for the interactive navigator.
 
 ## Included channels
 
@@ -47,14 +76,14 @@ Curated **English** and **Hindi** news channel playlists for an IPTV-like live T
 
 ## Refresh playlists
 
-Streams are pulled from the community-maintained [iptv-org/iptv](https://github.com/iptv-org/iptv) project. To update local playlists:
-
 ```bash
 python3 scripts/build-playlists.py
 ```
+
+Regenerates M3U playlists, `channels.json`, and `channel-guide.txt`.
 
 ## Notes
 
 - These are **free-to-air public streams** — availability varies by region and may change over time.
 - Some channels may be geo-blocked or marked `[Not 24/7]`.
-- VLC groups channels under **English News** and **Hindi News** in the playlist sidebar.
+- The combined playlist uses VLC `#EXTGRP` tags so Hindi and English appear as separate groups in the playlist tree.

--- a/credentials/.gitignore
+++ b/credentials/.gitignore
@@ -1,0 +1,4 @@
+# Google credentials (never commit real keys)
+credentials/
+*.json
+!iptv/channels.json

--- a/guide.html
+++ b/guide.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>News TV — Channel Guide</title>
+  <style>
+    :root {
+      --bg: #0b1018;
+      --panel: #141d2b;
+      --card: #1a2436;
+      --accent: #ff6b35;
+      --accent-2: #3dd6c6;
+      --text: #edf2f8;
+      --muted: #8fa3bf;
+      --border: #2a3850;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Segoe UI", system-ui, sans-serif;
+      background: radial-gradient(circle at top, #172033, var(--bg) 55%);
+      color: var(--text);
+      min-height: 100vh;
+    }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
+    h1 { margin: 0 0 0.35rem; font-size: 2rem; }
+    .subtitle { color: var(--muted); margin-bottom: 1.5rem; }
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-bottom: 1.25rem;
+      align-items: center;
+    }
+    input[type="search"] {
+      flex: 1 1 240px;
+      padding: 0.75rem 1rem;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--panel);
+      color: var(--text);
+      font-size: 1rem;
+    }
+    .filter-btn {
+      border: 1px solid var(--border);
+      background: var(--panel);
+      color: var(--text);
+      padding: 0.65rem 1rem;
+      border-radius: 999px;
+      cursor: pointer;
+    }
+    .filter-btn.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #111;
+      font-weight: 600;
+    }
+    .section { margin-top: 1.5rem; }
+    .section h2 {
+      font-size: 1rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--accent-2);
+      margin: 0 0 0.75rem;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 0.85rem;
+    }
+    .channel {
+      display: flex;
+      gap: 0.85rem;
+      align-items: center;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 0.85rem;
+      text-decoration: none;
+      color: inherit;
+      transition: transform 0.15s ease, border-color 0.15s ease;
+    }
+    .channel:hover {
+      transform: translateY(-2px);
+      border-color: var(--accent);
+    }
+    .num {
+      min-width: 2.6rem;
+      height: 2.6rem;
+      border-radius: 8px;
+      background: #0f1624;
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      color: var(--accent-2);
+      font-size: 0.9rem;
+    }
+    .logo {
+      width: 42px;
+      height: 42px;
+      object-fit: contain;
+      border-radius: 6px;
+      background: #0f1624;
+    }
+    .meta strong { display: block; font-size: 0.98rem; }
+    .meta span { color: var(--muted); font-size: 0.82rem; }
+    .shortcuts, .note {
+      margin-top: 1.5rem;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.15rem;
+      color: var(--muted);
+      line-height: 1.6;
+    }
+    code {
+      background: #0f1624;
+      padding: 0.1rem 0.35rem;
+      border-radius: 4px;
+      color: var(--text);
+    }
+    .empty { color: var(--muted); padding: 2rem 0; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>News TV Channel Guide</h1>
+    <p class="subtitle">Search by name or number, then click a channel to open it in VLC.</p>
+
+    <div class="toolbar">
+      <input id="search" type="search" placeholder="Search channels (e.g. 101, BBC, Aaj Tak)..." autofocus>
+      <button class="filter-btn active" data-filter="all">All</button>
+      <button class="filter-btn" data-filter="hindi">Hindi</button>
+      <button class="filter-btn" data-filter="english">English</button>
+    </div>
+
+    <div id="sections"></div>
+    <div id="empty" class="empty" hidden>No channels match your search.</div>
+
+    <div class="shortcuts">
+      <strong>VLC navigation shortcuts</strong><br>
+      <code>Ctrl+L</code> playlist sidebar (grouped) ·
+      <code>PgUp/PgDn</code> change channel ·
+      <code>F</code> fullscreen
+    </div>
+
+    <div class="note">
+      Clicking a channel opens the stream URL directly in VLC. For full channel-zapping,
+      run <code>./scripts/news-tv.sh</code> and pick a channel — it loads the full playlist
+      with your selection first.
+    </div>
+  </div>
+
+  <script>
+    let catalog = { hindi: [], english: [] };
+    let filter = "all";
+    let query = "";
+
+    async function loadCatalog() {
+      const res = await fetch("iptv/channels.json");
+      catalog = await res.json();
+      render();
+    }
+
+    function vlcUrl(url) {
+      return `vlc://${url}`;
+    }
+
+    function matches(ch) {
+      const q = query.trim().toLowerCase();
+      if (!q) return true;
+      if (q === String(ch.number)) return true;
+      if (String(ch.number).startsWith(q)) return true;
+      return ch.label.toLowerCase().includes(q);
+    }
+
+    function channelsFor(lang) {
+      if (lang === "hindi") return catalog.hindi || [];
+      if (lang === "english") return catalog.english || [];
+      return [...(catalog.hindi || []), ...(catalog.english || [])];
+    }
+
+    function renderSection(title, channels) {
+      const visible = channels.filter(matches);
+      if (!visible.length) return "";
+
+      const cards = visible.map(ch => `
+        <a class="channel" href="${vlcUrl(ch.url)}" title="Open in VLC">
+          <div class="num">${ch.number}</div>
+          ${ch.logo ? `<img class="logo" src="${ch.logo}" alt="" loading="lazy">` : ""}
+          <div class="meta">
+            <strong>${ch.label}</strong>
+            <span>${ch.language}</span>
+          </div>
+        </a>
+      `).join("");
+
+      return `<section class="section"><h2>${title}</h2><div class="grid">${cards}</div></section>`;
+    }
+
+    function render() {
+      const root = document.getElementById("sections");
+      let html = "";
+
+      if (filter === "all" || filter === "hindi") {
+        html += renderSection("Hindi News · 101–199", catalog.hindi || []);
+      }
+      if (filter === "all" || filter === "english") {
+        html += renderSection("English News · 201–299", catalog.english || []);
+      }
+
+      root.innerHTML = html;
+      const hasResults = root.textContent.trim().length > 0;
+      document.getElementById("empty").hidden = hasResults;
+    }
+
+    document.getElementById("search").addEventListener("input", (e) => {
+      query = e.target.value;
+      render();
+    });
+
+    document.querySelectorAll(".filter-btn").forEach(btn => {
+      btn.addEventListener("click", () => {
+        document.querySelectorAll(".filter-btn").forEach(b => b.classList.remove("active"));
+        btn.classList.add("active");
+        filter = btn.dataset.filter;
+        render();
+      });
+    });
+
+    loadCatalog().catch(() => {
+      document.getElementById("sections").innerHTML =
+        '<p class="empty">Run <code>python3 scripts/build-playlists.py</code> to generate channel data.</p>';
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>IPTV News Channels for VLC</title>
+  <style>
+    :root {
+      --bg: #0f1419;
+      --card: #1a2332;
+      --accent: #ff6b35;
+      --text: #e8edf4;
+      --muted: #8b9cb3;
+      --border: #2a3548;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Segoe UI", system-ui, sans-serif;
+      background: linear-gradient(160deg, #0f1419 0%, #1a2332 100%);
+      color: var(--text);
+      min-height: 100vh;
+    }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
+    h1 { font-size: 2rem; margin: 0 0 0.5rem; }
+    .subtitle { color: var(--muted); margin-bottom: 2rem; }
+    .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1.25rem;
+    }
+    .card h2 { margin: 0 0 0.75rem; font-size: 1.15rem; }
+    .card p { color: var(--muted); font-size: 0.95rem; line-height: 1.5; }
+    a.btn {
+      display: inline-block;
+      margin-top: 0.75rem;
+      padding: 0.55rem 1rem;
+      background: var(--accent);
+      color: #111;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+    }
+    a.btn.secondary { background: transparent; color: var(--text); border: 1px solid var(--border); }
+    code, pre {
+      background: #0b1018;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-size: 0.9rem;
+    }
+    code { padding: 0.15rem 0.4rem; }
+    pre { padding: 1rem; overflow-x: auto; }
+    ol { padding-left: 1.2rem; line-height: 1.7; }
+    .channels { columns: 2; gap: 1.5rem; font-size: 0.92rem; color: var(--muted); }
+    @media (max-width: 600px) { .channels { columns: 1; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>IPTV News for VLC</h1>
+    <p class="subtitle">Curated English and Hindi news channel playlists — open in VLC for an IPTV-style live TV experience.</p>
+
+    <div class="grid">
+      <div class="card">
+        <h2>English News</h2>
+        <p>International and Indian English news channels including BBC, Al Jazeera, NDTV 24x7, WION, and more.</p>
+        <a class="btn" href="iptv/english-news.m3u">Download playlist</a>
+      </div>
+      <div class="card">
+        <h2>Hindi News</h2>
+        <p>Major Hindi news channels including Aaj Tak, ABP News, NDTV India, Zee News, Republic Bharat, and more.</p>
+        <a class="btn" href="iptv/hindi-news.m3u">Download playlist</a>
+      </div>
+      <div class="card">
+        <h2>All News</h2>
+        <p>Combined playlist with both English and Hindi news channels in one file.</p>
+        <a class="btn" href="iptv/all-news.m3u">Download playlist</a>
+      </div>
+    </div>
+
+    <div class="card" style="margin-top: 1.5rem;">
+      <h2>Quick start with VLC</h2>
+      <ol>
+        <li>Install <a href="https://www.videolan.org/vlc/">VLC Media Player</a>.</li>
+        <li>Download a playlist above, or clone this repo.</li>
+        <li>In VLC: <strong>Media → Open File</strong> and select the <code>.m3u</code> file.</li>
+        <li>Open the playlist panel (<strong>View → Playlist</strong> or <code>Ctrl+L</code>) to browse channels.</li>
+        <li>Use <strong>Up/Down</strong> or <strong>PgUp/PgDn</strong> to switch channels like live TV.</li>
+      </ol>
+      <p>From the command line:</p>
+      <pre>git clone &lt;this-repo&gt;
+cd hello-world
+./scripts/watch-news.sh hindi
+./scripts/watch-news.sh english --channel 2</pre>
+    </div>
+
+    <div class="card" style="margin-top: 1rem;">
+      <h2>Included channels (sample)</h2>
+      <div class="channels">
+        <strong>English</strong>
+        <ul>
+          <li>Al Jazeera English</li>
+          <li>BBC News</li>
+          <li>France 24 English</li>
+          <li>DW English</li>
+          <li>Reuters</li>
+          <li>NDTV 24x7</li>
+          <li>WION</li>
+          <li>Times Now</li>
+          <li>Republic TV</li>
+          <li>CBS News 24/7</li>
+        </ul>
+        <strong>Hindi</strong>
+        <ul>
+          <li>Aaj Tak</li>
+          <li>ABP News</li>
+          <li>NDTV India</li>
+          <li>DD News</li>
+          <li>Zee News</li>
+          <li>Republic Bharat</li>
+          <li>TV9 Bharatvarsh</li>
+          <li>News18 India</li>
+          <li>India TV</li>
+          <li>Sansad TV</li>
+        </ul>
+      </div>
+    </div>
+
+    <p style="margin-top: 1.5rem; color: var(--muted); font-size: 0.85rem;">
+      Streams are sourced from publicly available free-to-air feeds indexed by
+      <a href="https://github.com/iptv-org/iptv">iptv-org/iptv</a>.
+      Availability may vary by region and over time. Run <code>python3 scripts/build-playlists.py</code> to refresh.
+    </p>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -60,9 +60,14 @@
 <body>
   <div class="wrap">
     <h1>IPTV News for VLC</h1>
-    <p class="subtitle">Curated English and Hindi news channel playlists — open in VLC for an IPTV-style live TV experience.</p>
+    <p class="subtitle">Curated English and Hindi news channels with numbered guides, grouped playlists, and an interactive navigator for VLC.</p>
 
     <div class="grid">
+      <div class="card">
+        <h2>Interactive Navigator</h2>
+        <p>Pick channels by number or name, then launch VLC with the full playlist ready for PgUp/PgDn zapping.</p>
+        <a class="btn" href="guide.html">Open Channel Guide</a>
+      </div>
       <div class="card">
         <h2>English News</h2>
         <p>International and Indian English news channels including BBC, Al Jazeera, NDTV 24x7, WION, and more.</p>
@@ -90,10 +95,10 @@
         <li>Use <strong>Up/Down</strong> or <strong>PgUp/PgDn</strong> to switch channels like live TV.</li>
       </ol>
       <p>From the command line:</p>
-      <pre>git clone &lt;this-repo&gt;
-cd hello-world
-./scripts/watch-news.sh hindi
-./scripts/watch-news.sh english --channel 2</pre>
+      <pre>./scripts/news-tv.sh                 # Interactive menu (recommended)
+./scripts/news-tv.sh --lang hindi --channel 101
+./scripts/news-tv.sh --search bbc
+./scripts/news-tv.sh --list</pre>
     </div>
 
     <div class="card" style="margin-top: 1rem;">

--- a/iptv/all-news.m3u
+++ b/iptv/all-news.m3u
@@ -1,0 +1,76 @@
+#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
+#PLAYLIST:Hindi News Channels
+#EXTINF:-1 tvg-id="AajTak.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png" group-title="Hindi News",Aaj Tak HD (1080p)
+https://feeds.intoday.in/aajtak/api/aajtakhd/master.m3u8
+#EXTINF:-1 tvg-id="ABPNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540" group-title="Hindi News",ABP News (1080p)
+https://d1rc86nwwc9fag.cloudfront.net/vglive-sk-472500/abpnews/master.m3u8
+#EXTINF:-1 tvg-id="NDTVIndia.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",NDTV India (720p)
+http://103.213.31.109:90/StarUtsavMovies/playlist.m3u8
+#EXTINF:-1 tvg-id="DDNews.in@HD" tvg-logo="https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png" group-title="Hindi News",DD News HD (1080p)
+https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/0811cd8c37ca4c409d5385a6cd2fa18b/index.m3u8
+#EXTINF:-1 tvg-id="ZeeNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540" group-title="Hindi News",Zee News (1080p)
+https://dknttpxmr0dwf.cloudfront.net/index_57.m3u8
+#EXTINF:-1 tvg-id="RepublicBharat.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540" group-title="Hindi News",Republic Bharat (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicBharat.m3u8
+#EXTINF:-1 tvg-id="TV9Bharatvarsh.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png" group-title="Hindi News",TV9 Bharatvarsh (720p)
+https://dyjmyiv3bp2ez.cloudfront.net/pub-iotv9hinjzgtpe/liveabr/playlist.m3u8
+#EXTINF:-1 tvg-id="News18India.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",News18 India (1080p)
+https://n18syndication.akamaized.net/bpk-tv/News18_India_NW18_MOB/output01/master.m3u8
+#EXTINF:-1 tvg-id="NewsNation.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png" group-title="Hindi News",News Nation (1080p)
+https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/6cd2f649739a45ca9de1daf81cc7d0f2/index.m3u8
+#EXTINF:-1 tvg-id="IndiaTV.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png" group-title="Hindi News",India TV (720p)
+https://pl-indiatvnews.akamaized.net/out/v1/db79179b608641ceaa5a4d0dd0dca8da/index.m3u8
+#EXTINF:-1 tvg-id="TimesNowNavbharat.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png" group-title="Hindi News",Times Now Navbharat (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/TimesNowNavbharat.m3u8
+#EXTINF:-1 tvg-id="BharatSamachar.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png" group-title="Hindi News",Bharat Samachar (576p)
+https://trs1.aynaott.com/BharatSamachar/index.m3u8
+#EXTINF:-1 tvg-id="GoodNewsToday.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png" group-title="Hindi News",Good News Today (720p)
+https://aajtaklive.vgcdn.net/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/3196cced-ce29-4219-9809-f07ccdaa02b9/vglive-sk-848805/master.m3u8
+#EXTINF:-1 tvg-id="SudarshanNews.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png" group-title="Hindi News",Sudarshan News (1080p)
+https://ott.livelegitpro.in/sudarshannews/sudarshannews/tracks-v1/index.fmp4.m3u8
+#EXTINF:-1 tvg-id="News24.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540" group-title="Hindi News",News 24 (720p)
+https://vidcdn.vidgyor.com/news24-origin/liveabr/playlist.m3u8
+#EXTINF:-1 tvg-id="SansadTV1.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png" group-title="Hindi News",Sansad TV 1 HD (1080p)
+https://d2lk5u59tns74c.cloudfront.net/out/v1/fff8f20221d5456e8922e689d71dedc3/index.m3u8
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="English News",Al Jazeera English (1080p)
+https://live-hls-apps-aje-fa.getaj.net/AJE/index.m3u8
+#EXTINF:-1 tvg-id="France24.fr@English" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png" group-title="English News",France 24 English (1080p)
+https://live.france24.com/hls/live/2037218-b/F24_EN_HI_HLS/master_5000.m3u8
+#EXTINF:-1 tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="English News",DW English (1080p)
+https://amg01644-amg01644c1-amgplt0343.playout.now3.amagi.tv/ts-eu-w1-n2/playlist/amg01644-amg01644c1-amgplt0343/playlist.m3u8
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png" group-title="English News",BBC News (1080p) [Geo-blocked]
+https://pb-iiczlgfysam0q.akamaized.net/v1/amcnetworks_bbcnews_1/samsungheadend_us/latest/main/hls/playlist.m3u8
+#EXTINF:-1 tvg-id="SkyNews.ie@SD" tvg-logo="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png" group-title="English News",Sky News (576p)
+http://41.205.77.102/SKYNEWS/index.m3u8
+#EXTINF:-1 tvg-id="ReutersTV.us@SD" tvg-logo="https://i.imgur.com/6eQ2nCJ.png" group-title="English News",Reuters (1080p)
+https://amg00453-reuters-amg00453c1-rakuten-uk-2110.playouts.now.amagi.tv/playlist/amg00453-reuters-reuters-rakutenuk/playlist.m3u8
+#EXTINF:-1 tvg-id="NDTV24x7.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png" group-title="English News",NDTV 24x7 (720p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/NDTV24x7.m3u8
+#EXTINF:-1 tvg-id="ABCNews.au@Sydney" tvg-logo="https://i.imgur.com/BrW7gk8.png" group-title="English News",ABC News (720p)
+https://abc-news-dmd-streams-1.akamaized.net/out/v1/701126012d044971b3fa89406a440133/index.m3u8
+#EXTINF:-1 tvg-id="CBSNews247.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png" group-title="English News",CBS News 24/7 (720p)
+https://jmp2.uk/plu-6350fdd266e9ea0007bedec5.m3u8
+#EXTINF:-1 tvg-id="FoxNewsChannel.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png" group-title="English News",Fox News Channel (720p)
+http://138.121.15.230:9002/FOX-NEWS/index.m3u8
+#EXTINF:-1 tvg-id="EuronewsEnglish.fr@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png" group-title="English News",Euronews English (720p)
+https://jmp2.uk/plu-61de96114757070008d33cae.m3u8
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png" group-title="English News",CGTN (1080p)
+https://amg00405-rakutentv-cgtn-rakuten-i9tar.amagi.tv/master.m3u8
+#EXTINF:-1 tvg-id="TRTWorld.tr@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png" group-title="English News",TRT World (1080p) [Not 24/7]
+https://tv-trtworld.medya.trt.com.tr/master.m3u8
+#EXTINF:-1 tvg-id="WION.in@SD" tvg-logo="https://i.imgur.com/Wc5Z3iS.png" group-title="English News",WION (1080p)
+http://vg-zeefta.akamaized.net/ptnr-yupptv/title-wion/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/20c3c0d9-0256-43fe-bca6-70fdd490b957/main.m3u8
+#EXTINF:-1 tvg-id="TimesNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png" http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0" group-title="English News",Times Now News (720p)
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0
+https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/times-now-news/master.m3u8?ads.vf=yxbqJWPCXd4
+#EXTINF:-1 tvg-id="RepublicTV.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540" group-title="English News",Republic TV (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicTV.m3u8
+#EXTINF:-1 tvg-id="MirrorNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png" http-referrer="https://www.timesnownews.com/" group-title="English News",Mirror Now (720p)
+#EXTVLCOPT:http-referrer=https://www.timesnownews.com/
+https://dai.google.com/linear/hls/event/ClPOullTQky5vGPf7fMZ8g/master.m3u8
+#EXTINF:-1 tvg-id="BloombergTV.us@US" tvg-logo="https://i.imgur.com/OuogLHx.png" group-title="English News",Bloomberg TV (1080p)
+http://23.237.104.106:8080/USA_BLOOMBERG/index.m3u8
+#EXTINF:-1 tvg-id="CNBCUK.uk@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png" group-title="English News",CNBC (1080p)
+https://amg01079-nbcuuk-amg01079c2-samsung-gb-1258.playouts.now.amagi.tv/playlist.m3u8
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png" group-title="English News",NHK World-Japan (1080p)
+https://masterpl.hls.nhkworld.jp/hls/w/live/smarttv.m3u8

--- a/iptv/all-news.m3u
+++ b/iptv/all-news.m3u
@@ -1,76 +1,78 @@
 #EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
-#PLAYLIST:Hindi News Channels
-#EXTINF:-1 tvg-id="AajTak.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png" group-title="Hindi News",Aaj Tak HD (1080p)
+#PLAYLIST:All News Channels
+#EXTGRP:Hindi News
+#EXTINF:-1 tvg-name="Aaj Tak" tvg-chno="101" tvg-language="Hindi" tvg-id="AajTak.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png" group-title="Hindi News",101 · Aaj Tak (1080p)
 https://feeds.intoday.in/aajtak/api/aajtakhd/master.m3u8
-#EXTINF:-1 tvg-id="ABPNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540" group-title="Hindi News",ABP News (1080p)
+#EXTINF:-1 tvg-name="ABP News" tvg-chno="102" tvg-language="Hindi" tvg-id="ABPNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540" group-title="Hindi News",102 · ABP News (1080p)
 https://d1rc86nwwc9fag.cloudfront.net/vglive-sk-472500/abpnews/master.m3u8
-#EXTINF:-1 tvg-id="NDTVIndia.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",NDTV India (720p)
+#EXTINF:-1 tvg-name="NDTV India" tvg-chno="103" tvg-language="Hindi" tvg-id="NDTVIndia.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",103 · NDTV India (720p)
 http://103.213.31.109:90/StarUtsavMovies/playlist.m3u8
-#EXTINF:-1 tvg-id="DDNews.in@HD" tvg-logo="https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png" group-title="Hindi News",DD News HD (1080p)
+#EXTINF:-1 tvg-name="DD News" tvg-chno="104" tvg-language="Hindi" tvg-id="DDNews.in@HD" tvg-logo="https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png" group-title="Hindi News",104 · DD News (1080p)
 https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/0811cd8c37ca4c409d5385a6cd2fa18b/index.m3u8
-#EXTINF:-1 tvg-id="ZeeNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540" group-title="Hindi News",Zee News (1080p)
+#EXTINF:-1 tvg-name="Zee News" tvg-chno="105" tvg-language="Hindi" tvg-id="ZeeNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540" group-title="Hindi News",105 · Zee News (1080p)
 https://dknttpxmr0dwf.cloudfront.net/index_57.m3u8
-#EXTINF:-1 tvg-id="RepublicBharat.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540" group-title="Hindi News",Republic Bharat (1080p)
+#EXTINF:-1 tvg-name="Republic Bharat" tvg-chno="106" tvg-language="Hindi" tvg-id="RepublicBharat.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540" group-title="Hindi News",106 · Republic Bharat (1080p)
 https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicBharat.m3u8
-#EXTINF:-1 tvg-id="TV9Bharatvarsh.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png" group-title="Hindi News",TV9 Bharatvarsh (720p)
+#EXTINF:-1 tvg-name="TV9 Bharatvarsh" tvg-chno="107" tvg-language="Hindi" tvg-id="TV9Bharatvarsh.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png" group-title="Hindi News",107 · TV9 Bharatvarsh (720p)
 https://dyjmyiv3bp2ez.cloudfront.net/pub-iotv9hinjzgtpe/liveabr/playlist.m3u8
-#EXTINF:-1 tvg-id="News18India.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",News18 India (1080p)
+#EXTINF:-1 tvg-name="News18 India" tvg-chno="108" tvg-language="Hindi" tvg-id="News18India.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",108 · News18 India (1080p)
 https://n18syndication.akamaized.net/bpk-tv/News18_India_NW18_MOB/output01/master.m3u8
-#EXTINF:-1 tvg-id="NewsNation.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png" group-title="Hindi News",News Nation (1080p)
+#EXTINF:-1 tvg-name="News Nation" tvg-chno="109" tvg-language="Hindi" tvg-id="NewsNation.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png" group-title="Hindi News",109 · News Nation (1080p)
 https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/6cd2f649739a45ca9de1daf81cc7d0f2/index.m3u8
-#EXTINF:-1 tvg-id="IndiaTV.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png" group-title="Hindi News",India TV (720p)
+#EXTINF:-1 tvg-name="India TV" tvg-chno="110" tvg-language="Hindi" tvg-id="IndiaTV.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png" group-title="Hindi News",110 · India TV (720p)
 https://pl-indiatvnews.akamaized.net/out/v1/db79179b608641ceaa5a4d0dd0dca8da/index.m3u8
-#EXTINF:-1 tvg-id="TimesNowNavbharat.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png" group-title="Hindi News",Times Now Navbharat (1080p)
+#EXTINF:-1 tvg-name="Times Now Navbharat" tvg-chno="111" tvg-language="Hindi" tvg-id="TimesNowNavbharat.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png" group-title="Hindi News",111 · Times Now Navbharat (1080p)
 https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/TimesNowNavbharat.m3u8
-#EXTINF:-1 tvg-id="BharatSamachar.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png" group-title="Hindi News",Bharat Samachar (576p)
+#EXTINF:-1 tvg-name="Bharat Samachar" tvg-chno="112" tvg-language="Hindi" tvg-id="BharatSamachar.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png" group-title="Hindi News",112 · Bharat Samachar (576p)
 https://trs1.aynaott.com/BharatSamachar/index.m3u8
-#EXTINF:-1 tvg-id="GoodNewsToday.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png" group-title="Hindi News",Good News Today (720p)
+#EXTINF:-1 tvg-name="Good News Today" tvg-chno="113" tvg-language="Hindi" tvg-id="GoodNewsToday.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png" group-title="Hindi News",113 · Good News Today (720p)
 https://aajtaklive.vgcdn.net/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/3196cced-ce29-4219-9809-f07ccdaa02b9/vglive-sk-848805/master.m3u8
-#EXTINF:-1 tvg-id="SudarshanNews.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png" group-title="Hindi News",Sudarshan News (1080p)
+#EXTINF:-1 tvg-name="Sudarshan News" tvg-chno="114" tvg-language="Hindi" tvg-id="SudarshanNews.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png" group-title="Hindi News",114 · Sudarshan News (1080p)
 https://ott.livelegitpro.in/sudarshannews/sudarshannews/tracks-v1/index.fmp4.m3u8
-#EXTINF:-1 tvg-id="News24.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540" group-title="Hindi News",News 24 (720p)
+#EXTINF:-1 tvg-name="News 24" tvg-chno="115" tvg-language="Hindi" tvg-id="News24.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540" group-title="Hindi News",115 · News 24 (720p)
 https://vidcdn.vidgyor.com/news24-origin/liveabr/playlist.m3u8
-#EXTINF:-1 tvg-id="SansadTV1.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png" group-title="Hindi News",Sansad TV 1 HD (1080p)
+#EXTINF:-1 tvg-name="Sansad TV" tvg-chno="116" tvg-language="Hindi" tvg-id="SansadTV1.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png" group-title="Hindi News",116 · Sansad TV (1080p)
 https://d2lk5u59tns74c.cloudfront.net/out/v1/fff8f20221d5456e8922e689d71dedc3/index.m3u8
-#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="English News",Al Jazeera English (1080p)
+#EXTGRP:English News
+#EXTINF:-1 tvg-name="Al Jazeera English" tvg-chno="201" tvg-language="English" tvg-id="AlJazeera.qa@English" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="English News",201 · Al Jazeera English (1080p)
 https://live-hls-apps-aje-fa.getaj.net/AJE/index.m3u8
-#EXTINF:-1 tvg-id="France24.fr@English" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png" group-title="English News",France 24 English (1080p)
+#EXTINF:-1 tvg-name="France 24 English" tvg-chno="202" tvg-language="English" tvg-id="France24.fr@English" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png" group-title="English News",202 · France 24 English (1080p)
 https://live.france24.com/hls/live/2037218-b/F24_EN_HI_HLS/master_5000.m3u8
-#EXTINF:-1 tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="English News",DW English (1080p)
+#EXTINF:-1 tvg-name="DW English" tvg-chno="203" tvg-language="English" tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="English News",203 · DW English (1080p)
 https://amg01644-amg01644c1-amgplt0343.playout.now3.amagi.tv/ts-eu-w1-n2/playlist/amg01644-amg01644c1-amgplt0343/playlist.m3u8
-#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png" group-title="English News",BBC News (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-name="BBC News" tvg-chno="204" tvg-language="English" tvg-id="BBCNews.uk@Europe" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png" group-title="English News",204 · BBC News (1080p)
 https://pb-iiczlgfysam0q.akamaized.net/v1/amcnetworks_bbcnews_1/samsungheadend_us/latest/main/hls/playlist.m3u8
-#EXTINF:-1 tvg-id="SkyNews.ie@SD" tvg-logo="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png" group-title="English News",Sky News (576p)
+#EXTINF:-1 tvg-name="Sky News" tvg-chno="205" tvg-language="English" tvg-id="SkyNews.ie@SD" tvg-logo="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png" group-title="English News",205 · Sky News (576p)
 http://41.205.77.102/SKYNEWS/index.m3u8
-#EXTINF:-1 tvg-id="ReutersTV.us@SD" tvg-logo="https://i.imgur.com/6eQ2nCJ.png" group-title="English News",Reuters (1080p)
+#EXTINF:-1 tvg-name="Reuters" tvg-chno="206" tvg-language="English" tvg-id="ReutersTV.us@SD" tvg-logo="https://i.imgur.com/6eQ2nCJ.png" group-title="English News",206 · Reuters (1080p)
 https://amg00453-reuters-amg00453c1-rakuten-uk-2110.playouts.now.amagi.tv/playlist/amg00453-reuters-reuters-rakutenuk/playlist.m3u8
-#EXTINF:-1 tvg-id="NDTV24x7.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png" group-title="English News",NDTV 24x7 (720p)
+#EXTINF:-1 tvg-name="NDTV 24x7" tvg-chno="207" tvg-language="English" tvg-id="NDTV24x7.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png" group-title="English News",207 · NDTV 24x7 (720p)
 https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/NDTV24x7.m3u8
-#EXTINF:-1 tvg-id="ABCNews.au@Sydney" tvg-logo="https://i.imgur.com/BrW7gk8.png" group-title="English News",ABC News (720p)
+#EXTINF:-1 tvg-name="ABC News Australia" tvg-chno="208" tvg-language="English" tvg-id="ABCNews.au@Sydney" tvg-logo="https://i.imgur.com/BrW7gk8.png" group-title="English News",208 · ABC News Australia (720p)
 https://abc-news-dmd-streams-1.akamaized.net/out/v1/701126012d044971b3fa89406a440133/index.m3u8
-#EXTINF:-1 tvg-id="CBSNews247.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png" group-title="English News",CBS News 24/7 (720p)
+#EXTINF:-1 tvg-name="CBS News 24/7" tvg-chno="209" tvg-language="English" tvg-id="CBSNews247.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png" group-title="English News",209 · CBS News 24/7 (720p)
 https://jmp2.uk/plu-6350fdd266e9ea0007bedec5.m3u8
-#EXTINF:-1 tvg-id="FoxNewsChannel.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png" group-title="English News",Fox News Channel (720p)
+#EXTINF:-1 tvg-name="Fox News" tvg-chno="210" tvg-language="English" tvg-id="FoxNewsChannel.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png" group-title="English News",210 · Fox News (720p)
 http://138.121.15.230:9002/FOX-NEWS/index.m3u8
-#EXTINF:-1 tvg-id="EuronewsEnglish.fr@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png" group-title="English News",Euronews English (720p)
+#EXTINF:-1 tvg-name="Euronews English" tvg-chno="211" tvg-language="English" tvg-id="EuronewsEnglish.fr@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png" group-title="English News",211 · Euronews English (720p)
 https://jmp2.uk/plu-61de96114757070008d33cae.m3u8
-#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png" group-title="English News",CGTN (1080p)
+#EXTINF:-1 tvg-name="CGTN" tvg-chno="212" tvg-language="English" tvg-id="CGTN.cn@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png" group-title="English News",212 · CGTN (1080p)
 https://amg00405-rakutentv-cgtn-rakuten-i9tar.amagi.tv/master.m3u8
-#EXTINF:-1 tvg-id="TRTWorld.tr@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png" group-title="English News",TRT World (1080p) [Not 24/7]
+#EXTINF:-1 tvg-name="TRT World" tvg-chno="213" tvg-language="English" tvg-id="TRTWorld.tr@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png" group-title="English News",213 · TRT World (1080p)
 https://tv-trtworld.medya.trt.com.tr/master.m3u8
-#EXTINF:-1 tvg-id="WION.in@SD" tvg-logo="https://i.imgur.com/Wc5Z3iS.png" group-title="English News",WION (1080p)
+#EXTINF:-1 tvg-name="WION" tvg-chno="214" tvg-language="English" tvg-id="WION.in@SD" tvg-logo="https://i.imgur.com/Wc5Z3iS.png" group-title="English News",214 · WION (1080p)
 http://vg-zeefta.akamaized.net/ptnr-yupptv/title-wion/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/20c3c0d9-0256-43fe-bca6-70fdd490b957/main.m3u8
-#EXTINF:-1 tvg-id="TimesNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png" http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0" group-title="English News",Times Now News (720p)
+#EXTINF:-1 tvg-name="Times Now" tvg-chno="215" tvg-language="English" tvg-id="TimesNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png" http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0" group-title="English News",215 · Times Now (720p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0
 https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/times-now-news/master.m3u8?ads.vf=yxbqJWPCXd4
-#EXTINF:-1 tvg-id="RepublicTV.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540" group-title="English News",Republic TV (1080p)
+#EXTINF:-1 tvg-name="Republic TV" tvg-chno="216" tvg-language="English" tvg-id="RepublicTV.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540" group-title="English News",216 · Republic TV (1080p)
 https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicTV.m3u8
-#EXTINF:-1 tvg-id="MirrorNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png" http-referrer="https://www.timesnownews.com/" group-title="English News",Mirror Now (720p)
+#EXTINF:-1 tvg-name="Mirror Now" tvg-chno="217" tvg-language="English" tvg-id="MirrorNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png" http-referrer="https://www.timesnownews.com/" group-title="English News",217 · Mirror Now (720p)
 #EXTVLCOPT:http-referrer=https://www.timesnownews.com/
 https://dai.google.com/linear/hls/event/ClPOullTQky5vGPf7fMZ8g/master.m3u8
-#EXTINF:-1 tvg-id="BloombergTV.us@US" tvg-logo="https://i.imgur.com/OuogLHx.png" group-title="English News",Bloomberg TV (1080p)
+#EXTINF:-1 tvg-name="Bloomberg TV" tvg-chno="218" tvg-language="English" tvg-id="BloombergTV.us@US" tvg-logo="https://i.imgur.com/OuogLHx.png" group-title="English News",218 · Bloomberg TV (1080p)
 http://23.237.104.106:8080/USA_BLOOMBERG/index.m3u8
-#EXTINF:-1 tvg-id="CNBCUK.uk@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png" group-title="English News",CNBC (1080p)
+#EXTINF:-1 tvg-name="CNBC" tvg-chno="219" tvg-language="English" tvg-id="CNBCUK.uk@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png" group-title="English News",219 · CNBC (1080p)
 https://amg01079-nbcuuk-amg01079c2-samsung-gb-1258.playouts.now.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png" group-title="English News",NHK World-Japan (1080p)
+#EXTINF:-1 tvg-name="NHK World" tvg-chno="220" tvg-language="English" tvg-id="NHKWorldJapan.jp@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png" group-title="English News",220 · NHK World (1080p)
 https://masterpl.hls.nhkworld.jp/hls/w/live/smarttv.m3u8

--- a/iptv/channel-guide.txt
+++ b/iptv/channel-guide.txt
@@ -1,0 +1,53 @@
+NEWS TV — Channel Guide
+=======================
+
+Hindi News (101–199)
+--------------------
+  101  Aaj Tak
+  102  ABP News
+  103  NDTV India
+  104  DD News
+  105  Zee News
+  106  Republic Bharat
+  107  TV9 Bharatvarsh
+  108  News18 India
+  109  News Nation
+  110  India TV
+  111  Times Now Navbharat
+  112  Bharat Samachar
+  113  Good News Today
+  114  Sudarshan News
+  115  News 24
+  116  Sansad TV
+
+English News (201–299)
+----------------------
+  201  Al Jazeera English
+  202  France 24 English
+  203  DW English
+  204  BBC News
+  205  Sky News
+  206  Reuters
+  207  NDTV 24x7
+  208  ABC News Australia
+  209  CBS News 24/7
+  210  Fox News
+  211  Euronews English
+  212  CGTN
+  213  TRT World
+  214  WION
+  215  Times Now
+  216  Republic TV
+  217  Mirror Now
+  218  Bloomberg TV
+  219  CNBC
+  220  NHK World
+
+VLC shortcuts
+-------------
+  Ctrl+L     Open playlist sidebar
+  PgUp/PgDn  Previous / next channel
+  Up/Down    Fine channel step
+  F          Fullscreen
+
+Launch: ./scripts/news-tv.sh

--- a/iptv/channels.json
+++ b/iptv/channels.json
@@ -1,0 +1,330 @@
+{
+  "hindi": [
+    {
+      "number": 101,
+      "label": "Aaj Tak",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "101 \u00b7 Aaj Tak (1080p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png",
+      "url": "https://feeds.intoday.in/aajtak/api/aajtakhd/master.m3u8"
+    },
+    {
+      "number": 102,
+      "label": "ABP News",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "102 \u00b7 ABP News (1080p)",
+      "logo": "https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540",
+      "url": "https://d1rc86nwwc9fag.cloudfront.net/vglive-sk-472500/abpnews/master.m3u8"
+    },
+    {
+      "number": 103,
+      "label": "NDTV India",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "103 \u00b7 NDTV India (720p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png",
+      "url": "http://103.213.31.109:90/StarUtsavMovies/playlist.m3u8"
+    },
+    {
+      "number": 104,
+      "label": "DD News",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "104 \u00b7 DD News (1080p)",
+      "logo": "https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png",
+      "url": "https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/0811cd8c37ca4c409d5385a6cd2fa18b/index.m3u8"
+    },
+    {
+      "number": 105,
+      "label": "Zee News",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "105 \u00b7 Zee News (1080p)",
+      "logo": "https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540",
+      "url": "https://dknttpxmr0dwf.cloudfront.net/index_57.m3u8"
+    },
+    {
+      "number": 106,
+      "label": "Republic Bharat",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "106 \u00b7 Republic Bharat (1080p)",
+      "logo": "https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540",
+      "url": "https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicBharat.m3u8"
+    },
+    {
+      "number": 107,
+      "label": "TV9 Bharatvarsh",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "107 \u00b7 TV9 Bharatvarsh (720p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png",
+      "url": "https://dyjmyiv3bp2ez.cloudfront.net/pub-iotv9hinjzgtpe/liveabr/playlist.m3u8"
+    },
+    {
+      "number": 108,
+      "label": "News18 India",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "108 \u00b7 News18 India (1080p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png",
+      "url": "https://n18syndication.akamaized.net/bpk-tv/News18_India_NW18_MOB/output01/master.m3u8"
+    },
+    {
+      "number": 109,
+      "label": "News Nation",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "109 \u00b7 News Nation (1080p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png",
+      "url": "https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/6cd2f649739a45ca9de1daf81cc7d0f2/index.m3u8"
+    },
+    {
+      "number": 110,
+      "label": "India TV",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "110 \u00b7 India TV (720p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png",
+      "url": "https://pl-indiatvnews.akamaized.net/out/v1/db79179b608641ceaa5a4d0dd0dca8da/index.m3u8"
+    },
+    {
+      "number": 111,
+      "label": "Times Now Navbharat",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "111 \u00b7 Times Now Navbharat (1080p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png",
+      "url": "https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/TimesNowNavbharat.m3u8"
+    },
+    {
+      "number": 112,
+      "label": "Bharat Samachar",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "112 \u00b7 Bharat Samachar (576p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png",
+      "url": "https://trs1.aynaott.com/BharatSamachar/index.m3u8"
+    },
+    {
+      "number": 113,
+      "label": "Good News Today",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "113 \u00b7 Good News Today (720p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png",
+      "url": "https://aajtaklive.vgcdn.net/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/3196cced-ce29-4219-9809-f07ccdaa02b9/vglive-sk-848805/master.m3u8"
+    },
+    {
+      "number": 114,
+      "label": "Sudarshan News",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "114 \u00b7 Sudarshan News (1080p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png",
+      "url": "https://ott.livelegitpro.in/sudarshannews/sudarshannews/tracks-v1/index.fmp4.m3u8"
+    },
+    {
+      "number": 115,
+      "label": "News 24",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "115 \u00b7 News 24 (720p)",
+      "logo": "https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540",
+      "url": "https://vidcdn.vidgyor.com/news24-origin/liveabr/playlist.m3u8"
+    },
+    {
+      "number": 116,
+      "label": "Sansad TV",
+      "group": "Hindi News",
+      "language": "Hindi",
+      "display": "116 \u00b7 Sansad TV (1080p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png",
+      "url": "https://d2lk5u59tns74c.cloudfront.net/out/v1/fff8f20221d5456e8922e689d71dedc3/index.m3u8"
+    }
+  ],
+  "english": [
+    {
+      "number": 201,
+      "label": "Al Jazeera English",
+      "group": "English News",
+      "language": "English",
+      "display": "201 \u00b7 Al Jazeera English (1080p)",
+      "logo": "https://i.imgur.com/7bRVpnu.png",
+      "url": "https://live-hls-apps-aje-fa.getaj.net/AJE/index.m3u8"
+    },
+    {
+      "number": 202,
+      "label": "France 24 English",
+      "group": "English News",
+      "language": "English",
+      "display": "202 \u00b7 France 24 English (1080p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png",
+      "url": "https://live.france24.com/hls/live/2037218-b/F24_EN_HI_HLS/master_5000.m3u8"
+    },
+    {
+      "number": 203,
+      "label": "DW English",
+      "group": "English News",
+      "language": "English",
+      "display": "203 \u00b7 DW English (1080p)",
+      "logo": "https://i.imgur.com/8MRNFb9.png",
+      "url": "https://amg01644-amg01644c1-amgplt0343.playout.now3.amagi.tv/ts-eu-w1-n2/playlist/amg01644-amg01644c1-amgplt0343/playlist.m3u8"
+    },
+    {
+      "number": 204,
+      "label": "BBC News",
+      "group": "English News",
+      "language": "English",
+      "display": "204 \u00b7 BBC News (1080p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png",
+      "url": "https://pb-iiczlgfysam0q.akamaized.net/v1/amcnetworks_bbcnews_1/samsungheadend_us/latest/main/hls/playlist.m3u8"
+    },
+    {
+      "number": 205,
+      "label": "Sky News",
+      "group": "English News",
+      "language": "English",
+      "display": "205 \u00b7 Sky News (576p)",
+      "logo": "https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png",
+      "url": "http://41.205.77.102/SKYNEWS/index.m3u8"
+    },
+    {
+      "number": 206,
+      "label": "Reuters",
+      "group": "English News",
+      "language": "English",
+      "display": "206 \u00b7 Reuters (1080p)",
+      "logo": "https://i.imgur.com/6eQ2nCJ.png",
+      "url": "https://amg00453-reuters-amg00453c1-rakuten-uk-2110.playouts.now.amagi.tv/playlist/amg00453-reuters-reuters-rakutenuk/playlist.m3u8"
+    },
+    {
+      "number": 207,
+      "label": "NDTV 24x7",
+      "group": "English News",
+      "language": "English",
+      "display": "207 \u00b7 NDTV 24x7 (720p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png",
+      "url": "https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/NDTV24x7.m3u8"
+    },
+    {
+      "number": 208,
+      "label": "ABC News Australia",
+      "group": "English News",
+      "language": "English",
+      "display": "208 \u00b7 ABC News Australia (720p)",
+      "logo": "https://i.imgur.com/BrW7gk8.png",
+      "url": "https://abc-news-dmd-streams-1.akamaized.net/out/v1/701126012d044971b3fa89406a440133/index.m3u8"
+    },
+    {
+      "number": 209,
+      "label": "CBS News 24/7",
+      "group": "English News",
+      "language": "English",
+      "display": "209 \u00b7 CBS News 24/7 (720p)",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png",
+      "url": "https://jmp2.uk/plu-6350fdd266e9ea0007bedec5.m3u8"
+    },
+    {
+      "number": 210,
+      "label": "Fox News",
+      "group": "English News",
+      "language": "English",
+      "display": "210 \u00b7 Fox News (720p)",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png",
+      "url": "http://138.121.15.230:9002/FOX-NEWS/index.m3u8"
+    },
+    {
+      "number": 211,
+      "label": "Euronews English",
+      "group": "English News",
+      "language": "English",
+      "display": "211 \u00b7 Euronews English (720p)",
+      "logo": "https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png",
+      "url": "https://jmp2.uk/plu-61de96114757070008d33cae.m3u8"
+    },
+    {
+      "number": 212,
+      "label": "CGTN",
+      "group": "English News",
+      "language": "English",
+      "display": "212 \u00b7 CGTN (1080p)",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png",
+      "url": "https://amg00405-rakutentv-cgtn-rakuten-i9tar.amagi.tv/master.m3u8"
+    },
+    {
+      "number": 213,
+      "label": "TRT World",
+      "group": "English News",
+      "language": "English",
+      "display": "213 \u00b7 TRT World (1080p)",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png",
+      "url": "https://tv-trtworld.medya.trt.com.tr/master.m3u8"
+    },
+    {
+      "number": 214,
+      "label": "WION",
+      "group": "English News",
+      "language": "English",
+      "display": "214 \u00b7 WION (1080p)",
+      "logo": "https://i.imgur.com/Wc5Z3iS.png",
+      "url": "http://vg-zeefta.akamaized.net/ptnr-yupptv/title-wion/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/20c3c0d9-0256-43fe-bca6-70fdd490b957/main.m3u8"
+    },
+    {
+      "number": 215,
+      "label": "Times Now",
+      "group": "English News",
+      "language": "English",
+      "display": "215 \u00b7 Times Now (720p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png",
+      "url": "https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/times-now-news/master.m3u8?ads.vf=yxbqJWPCXd4"
+    },
+    {
+      "number": 216,
+      "label": "Republic TV",
+      "group": "English News",
+      "language": "English",
+      "display": "216 \u00b7 Republic TV (1080p)",
+      "logo": "https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540",
+      "url": "https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicTV.m3u8"
+    },
+    {
+      "number": 217,
+      "label": "Mirror Now",
+      "group": "English News",
+      "language": "English",
+      "display": "217 \u00b7 Mirror Now (720p)",
+      "logo": "https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png",
+      "url": "https://dai.google.com/linear/hls/event/ClPOullTQky5vGPf7fMZ8g/master.m3u8"
+    },
+    {
+      "number": 218,
+      "label": "Bloomberg TV",
+      "group": "English News",
+      "language": "English",
+      "display": "218 \u00b7 Bloomberg TV (1080p)",
+      "logo": "https://i.imgur.com/OuogLHx.png",
+      "url": "http://23.237.104.106:8080/USA_BLOOMBERG/index.m3u8"
+    },
+    {
+      "number": 219,
+      "label": "CNBC",
+      "group": "English News",
+      "language": "English",
+      "display": "219 \u00b7 CNBC (1080p)",
+      "logo": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png",
+      "url": "https://amg01079-nbcuuk-amg01079c2-samsung-gb-1258.playouts.now.amagi.tv/playlist.m3u8"
+    },
+    {
+      "number": 220,
+      "label": "NHK World",
+      "group": "English News",
+      "language": "English",
+      "display": "220 \u00b7 NHK World (1080p)",
+      "logo": "https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png",
+      "url": "https://masterpl.hls.nhkworld.jp/hls/w/live/smarttv.m3u8"
+    }
+  ]
+}

--- a/iptv/english-news.m3u
+++ b/iptv/english-news.m3u
@@ -1,0 +1,44 @@
+#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
+#PLAYLIST:English News Channels
+#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="English News",Al Jazeera English (1080p)
+https://live-hls-apps-aje-fa.getaj.net/AJE/index.m3u8
+#EXTINF:-1 tvg-id="France24.fr@English" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png" group-title="English News",France 24 English (1080p)
+https://live.france24.com/hls/live/2037218-b/F24_EN_HI_HLS/master_5000.m3u8
+#EXTINF:-1 tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="English News",DW English (1080p)
+https://amg01644-amg01644c1-amgplt0343.playout.now3.amagi.tv/ts-eu-w1-n2/playlist/amg01644-amg01644c1-amgplt0343/playlist.m3u8
+#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png" group-title="English News",BBC News (1080p) [Geo-blocked]
+https://pb-iiczlgfysam0q.akamaized.net/v1/amcnetworks_bbcnews_1/samsungheadend_us/latest/main/hls/playlist.m3u8
+#EXTINF:-1 tvg-id="SkyNews.ie@SD" tvg-logo="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png" group-title="English News",Sky News (576p)
+http://41.205.77.102/SKYNEWS/index.m3u8
+#EXTINF:-1 tvg-id="ReutersTV.us@SD" tvg-logo="https://i.imgur.com/6eQ2nCJ.png" group-title="English News",Reuters (1080p)
+https://amg00453-reuters-amg00453c1-rakuten-uk-2110.playouts.now.amagi.tv/playlist/amg00453-reuters-reuters-rakutenuk/playlist.m3u8
+#EXTINF:-1 tvg-id="NDTV24x7.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png" group-title="English News",NDTV 24x7 (720p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/NDTV24x7.m3u8
+#EXTINF:-1 tvg-id="ABCNews.au@Sydney" tvg-logo="https://i.imgur.com/BrW7gk8.png" group-title="English News",ABC News (720p)
+https://abc-news-dmd-streams-1.akamaized.net/out/v1/701126012d044971b3fa89406a440133/index.m3u8
+#EXTINF:-1 tvg-id="CBSNews247.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png" group-title="English News",CBS News 24/7 (720p)
+https://jmp2.uk/plu-6350fdd266e9ea0007bedec5.m3u8
+#EXTINF:-1 tvg-id="FoxNewsChannel.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png" group-title="English News",Fox News Channel (720p)
+http://138.121.15.230:9002/FOX-NEWS/index.m3u8
+#EXTINF:-1 tvg-id="EuronewsEnglish.fr@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png" group-title="English News",Euronews English (720p)
+https://jmp2.uk/plu-61de96114757070008d33cae.m3u8
+#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png" group-title="English News",CGTN (1080p)
+https://amg00405-rakutentv-cgtn-rakuten-i9tar.amagi.tv/master.m3u8
+#EXTINF:-1 tvg-id="TRTWorld.tr@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png" group-title="English News",TRT World (1080p) [Not 24/7]
+https://tv-trtworld.medya.trt.com.tr/master.m3u8
+#EXTINF:-1 tvg-id="WION.in@SD" tvg-logo="https://i.imgur.com/Wc5Z3iS.png" group-title="English News",WION (1080p)
+http://vg-zeefta.akamaized.net/ptnr-yupptv/title-wion/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/20c3c0d9-0256-43fe-bca6-70fdd490b957/main.m3u8
+#EXTINF:-1 tvg-id="TimesNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png" http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0" group-title="English News",Times Now News (720p)
+#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0
+https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/times-now-news/master.m3u8?ads.vf=yxbqJWPCXd4
+#EXTINF:-1 tvg-id="RepublicTV.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540" group-title="English News",Republic TV (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicTV.m3u8
+#EXTINF:-1 tvg-id="MirrorNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png" http-referrer="https://www.timesnownews.com/" group-title="English News",Mirror Now (720p)
+#EXTVLCOPT:http-referrer=https://www.timesnownews.com/
+https://dai.google.com/linear/hls/event/ClPOullTQky5vGPf7fMZ8g/master.m3u8
+#EXTINF:-1 tvg-id="BloombergTV.us@US" tvg-logo="https://i.imgur.com/OuogLHx.png" group-title="English News",Bloomberg TV (1080p)
+http://23.237.104.106:8080/USA_BLOOMBERG/index.m3u8
+#EXTINF:-1 tvg-id="CNBCUK.uk@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png" group-title="English News",CNBC (1080p)
+https://amg01079-nbcuuk-amg01079c2-samsung-gb-1258.playouts.now.amagi.tv/playlist.m3u8
+#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png" group-title="English News",NHK World-Japan (1080p)
+https://masterpl.hls.nhkworld.jp/hls/w/live/smarttv.m3u8

--- a/iptv/english-news.m3u
+++ b/iptv/english-news.m3u
@@ -1,44 +1,44 @@
 #EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
 #PLAYLIST:English News Channels
-#EXTINF:-1 tvg-id="AlJazeera.qa@English" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="English News",Al Jazeera English (1080p)
+#EXTINF:-1 tvg-name="Al Jazeera English" tvg-chno="201" tvg-language="English" tvg-id="AlJazeera.qa@English" tvg-logo="https://i.imgur.com/7bRVpnu.png" group-title="English News",201 · Al Jazeera English (1080p)
 https://live-hls-apps-aje-fa.getaj.net/AJE/index.m3u8
-#EXTINF:-1 tvg-id="France24.fr@English" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png" group-title="English News",France 24 English (1080p)
+#EXTINF:-1 tvg-name="France 24 English" tvg-chno="202" tvg-language="English" tvg-id="France24.fr@English" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_FRANCE_24/images/LOGO_HD/image.png" group-title="English News",202 · France 24 English (1080p)
 https://live.france24.com/hls/live/2037218-b/F24_EN_HI_HLS/master_5000.m3u8
-#EXTINF:-1 tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="English News",DW English (1080p)
+#EXTINF:-1 tvg-name="DW English" tvg-chno="203" tvg-language="English" tvg-id="DW.de@English" tvg-logo="https://i.imgur.com/8MRNFb9.png" group-title="English News",203 · DW English (1080p)
 https://amg01644-amg01644c1-amgplt0343.playout.now3.amagi.tv/ts-eu-w1-n2/playlist/amg01644-amg01644c1-amgplt0343/playlist.m3u8
-#EXTINF:-1 tvg-id="BBCNews.uk@Europe" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png" group-title="English News",BBC News (1080p) [Geo-blocked]
+#EXTINF:-1 tvg-name="BBC News" tvg-chno="204" tvg-language="English" tvg-id="BBCNews.uk@Europe" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BBC_NEWS/images/LOGO_HD/image.png" group-title="English News",204 · BBC News (1080p)
 https://pb-iiczlgfysam0q.akamaized.net/v1/amcnetworks_bbcnews_1/samsungheadend_us/latest/main/hls/playlist.m3u8
-#EXTINF:-1 tvg-id="SkyNews.ie@SD" tvg-logo="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png" group-title="English News",Sky News (576p)
+#EXTINF:-1 tvg-name="Sky News" tvg-chno="205" tvg-language="English" tvg-id="SkyNews.ie@SD" tvg-logo="https://d2n0069hmnqmmx.cloudfront.net/epgdata/1.0/newchanlogos/512/512/skychb1404.png" group-title="English News",205 · Sky News (576p)
 http://41.205.77.102/SKYNEWS/index.m3u8
-#EXTINF:-1 tvg-id="ReutersTV.us@SD" tvg-logo="https://i.imgur.com/6eQ2nCJ.png" group-title="English News",Reuters (1080p)
+#EXTINF:-1 tvg-name="Reuters" tvg-chno="206" tvg-language="English" tvg-id="ReutersTV.us@SD" tvg-logo="https://i.imgur.com/6eQ2nCJ.png" group-title="English News",206 · Reuters (1080p)
 https://amg00453-reuters-amg00453c1-rakuten-uk-2110.playouts.now.amagi.tv/playlist/amg00453-reuters-reuters-rakutenuk/playlist.m3u8
-#EXTINF:-1 tvg-id="NDTV24x7.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png" group-title="English News",NDTV 24x7 (720p)
+#EXTINF:-1 tvg-name="NDTV 24x7" tvg-chno="207" tvg-language="English" tvg-id="NDTV24x7.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_24X7/images/LOGO_HD/image.png" group-title="English News",207 · NDTV 24x7 (720p)
 https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/NDTV24x7.m3u8
-#EXTINF:-1 tvg-id="ABCNews.au@Sydney" tvg-logo="https://i.imgur.com/BrW7gk8.png" group-title="English News",ABC News (720p)
+#EXTINF:-1 tvg-name="ABC News Australia" tvg-chno="208" tvg-language="English" tvg-id="ABCNews.au@Sydney" tvg-logo="https://i.imgur.com/BrW7gk8.png" group-title="English News",208 · ABC News Australia (720p)
 https://abc-news-dmd-streams-1.akamaized.net/out/v1/701126012d044971b3fa89406a440133/index.m3u8
-#EXTINF:-1 tvg-id="CBSNews247.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png" group-title="English News",CBS News 24/7 (720p)
+#EXTINF:-1 tvg-name="CBS News 24/7" tvg-chno="209" tvg-language="English" tvg-id="CBSNews247.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/CBS_News_247_logo.svg/960px-CBS_News_247_logo.svg.png" group-title="English News",209 · CBS News 24/7 (720p)
 https://jmp2.uk/plu-6350fdd266e9ea0007bedec5.m3u8
-#EXTINF:-1 tvg-id="FoxNewsChannel.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png" group-title="English News",Fox News Channel (720p)
+#EXTINF:-1 tvg-name="Fox News" tvg-chno="210" tvg-language="English" tvg-id="FoxNewsChannel.us@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/6/67/Fox_News_Channel_logo.svg/960px-Fox_News_Channel_logo.svg.png" group-title="English News",210 · Fox News (720p)
 http://138.121.15.230:9002/FOX-NEWS/index.m3u8
-#EXTINF:-1 tvg-id="EuronewsEnglish.fr@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png" group-title="English News",Euronews English (720p)
+#EXTINF:-1 tvg-name="Euronews English" tvg-chno="211" tvg-language="English" tvg-id="EuronewsEnglish.fr@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/Euro_News.png" group-title="English News",211 · Euronews English (720p)
 https://jmp2.uk/plu-61de96114757070008d33cae.m3u8
-#EXTINF:-1 tvg-id="CGTN.cn@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png" group-title="English News",CGTN (1080p)
+#EXTINF:-1 tvg-name="CGTN" tvg-chno="212" tvg-language="English" tvg-id="CGTN.cn@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/CGTN.svg/960px-CGTN.svg.png" group-title="English News",212 · CGTN (1080p)
 https://amg00405-rakutentv-cgtn-rakuten-i9tar.amagi.tv/master.m3u8
-#EXTINF:-1 tvg-id="TRTWorld.tr@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png" group-title="English News",TRT World (1080p) [Not 24/7]
+#EXTINF:-1 tvg-name="TRT World" tvg-chno="213" tvg-language="English" tvg-id="TRTWorld.tr@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/TRT_World.svg/960px-TRT_World.svg.png" group-title="English News",213 · TRT World (1080p)
 https://tv-trtworld.medya.trt.com.tr/master.m3u8
-#EXTINF:-1 tvg-id="WION.in@SD" tvg-logo="https://i.imgur.com/Wc5Z3iS.png" group-title="English News",WION (1080p)
+#EXTINF:-1 tvg-name="WION" tvg-chno="214" tvg-language="English" tvg-id="WION.in@SD" tvg-logo="https://i.imgur.com/Wc5Z3iS.png" group-title="English News",214 · WION (1080p)
 http://vg-zeefta.akamaized.net/ptnr-yupptv/title-wion/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/20c3c0d9-0256-43fe-bca6-70fdd490b957/main.m3u8
-#EXTINF:-1 tvg-id="TimesNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png" http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0" group-title="English News",Times Now News (720p)
+#EXTINF:-1 tvg-name="Times Now" tvg-chno="215" tvg-language="English" tvg-id="TimesNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW/images/LOGO_HD/image.png" http-user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0" group-title="English News",215 · Times Now (720p)
 #EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0
 https://d35j504z0x2vu2.cloudfront.net/v1/master/0bc8e8376bd8417a1b6761138aa41c26c7309312/times-now-news/master.m3u8?ads.vf=yxbqJWPCXd4
-#EXTINF:-1 tvg-id="RepublicTV.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540" group-title="English News",Republic TV (1080p)
+#EXTINF:-1 tvg-name="Republic TV" tvg-chno="216" tvg-language="English" tvg-id="RepublicTV.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143723_ld_h15_aa.png?lock=720x540" group-title="English News",216 · Republic TV (1080p)
 https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicTV.m3u8
-#EXTINF:-1 tvg-id="MirrorNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png" http-referrer="https://www.timesnownews.com/" group-title="English News",Mirror Now (720p)
+#EXTINF:-1 tvg-name="Mirror Now" tvg-chno="217" tvg-language="English" tvg-id="MirrorNow.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_MIRROR_NOW/images/LOGO_HD/image.png" http-referrer="https://www.timesnownews.com/" group-title="English News",217 · Mirror Now (720p)
 #EXTVLCOPT:http-referrer=https://www.timesnownews.com/
 https://dai.google.com/linear/hls/event/ClPOullTQky5vGPf7fMZ8g/master.m3u8
-#EXTINF:-1 tvg-id="BloombergTV.us@US" tvg-logo="https://i.imgur.com/OuogLHx.png" group-title="English News",Bloomberg TV (1080p)
+#EXTINF:-1 tvg-name="Bloomberg TV" tvg-chno="218" tvg-language="English" tvg-id="BloombergTV.us@US" tvg-logo="https://i.imgur.com/OuogLHx.png" group-title="English News",218 · Bloomberg TV (1080p)
 http://23.237.104.106:8080/USA_BLOOMBERG/index.m3u8
-#EXTINF:-1 tvg-id="CNBCUK.uk@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png" group-title="English News",CNBC (1080p)
+#EXTINF:-1 tvg-name="CNBC" tvg-chno="219" tvg-language="English" tvg-id="CNBCUK.uk@SD" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/CNBC_2025.svg/960px-CNBC_2025.svg.png" group-title="English News",219 · CNBC (1080p)
 https://amg01079-nbcuuk-amg01079c2-samsung-gb-1258.playouts.now.amagi.tv/playlist.m3u8
-#EXTINF:-1 tvg-id="NHKWorldJapan.jp@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png" group-title="English News",NHK World-Japan (1080p)
+#EXTINF:-1 tvg-name="NHK World" tvg-chno="220" tvg-language="English" tvg-id="NHKWorldJapan.jp@SD" tvg-logo="https://jiotvimages.cdn.jio.com/dare_images/images/NHK_World_Japan.png" group-title="English News",220 · NHK World (1080p)
 https://masterpl.hls.nhkworld.jp/hls/w/live/smarttv.m3u8

--- a/iptv/hindi-news.m3u
+++ b/iptv/hindi-news.m3u
@@ -1,34 +1,34 @@
 #EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
 #PLAYLIST:Hindi News Channels
-#EXTINF:-1 tvg-id="AajTak.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png" group-title="Hindi News",Aaj Tak HD (1080p)
+#EXTINF:-1 tvg-name="Aaj Tak" tvg-chno="101" tvg-language="Hindi" tvg-id="AajTak.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png" group-title="Hindi News",101 · Aaj Tak (1080p)
 https://feeds.intoday.in/aajtak/api/aajtakhd/master.m3u8
-#EXTINF:-1 tvg-id="ABPNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540" group-title="Hindi News",ABP News (1080p)
+#EXTINF:-1 tvg-name="ABP News" tvg-chno="102" tvg-language="Hindi" tvg-id="ABPNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540" group-title="Hindi News",102 · ABP News (1080p)
 https://d1rc86nwwc9fag.cloudfront.net/vglive-sk-472500/abpnews/master.m3u8
-#EXTINF:-1 tvg-id="NDTVIndia.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",NDTV India (720p)
+#EXTINF:-1 tvg-name="NDTV India" tvg-chno="103" tvg-language="Hindi" tvg-id="NDTVIndia.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",103 · NDTV India (720p)
 http://103.213.31.109:90/StarUtsavMovies/playlist.m3u8
-#EXTINF:-1 tvg-id="DDNews.in@HD" tvg-logo="https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png" group-title="Hindi News",DD News HD (1080p)
+#EXTINF:-1 tvg-name="DD News" tvg-chno="104" tvg-language="Hindi" tvg-id="DDNews.in@HD" tvg-logo="https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png" group-title="Hindi News",104 · DD News (1080p)
 https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/0811cd8c37ca4c409d5385a6cd2fa18b/index.m3u8
-#EXTINF:-1 tvg-id="ZeeNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540" group-title="Hindi News",Zee News (1080p)
+#EXTINF:-1 tvg-name="Zee News" tvg-chno="105" tvg-language="Hindi" tvg-id="ZeeNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540" group-title="Hindi News",105 · Zee News (1080p)
 https://dknttpxmr0dwf.cloudfront.net/index_57.m3u8
-#EXTINF:-1 tvg-id="RepublicBharat.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540" group-title="Hindi News",Republic Bharat (1080p)
+#EXTINF:-1 tvg-name="Republic Bharat" tvg-chno="106" tvg-language="Hindi" tvg-id="RepublicBharat.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540" group-title="Hindi News",106 · Republic Bharat (1080p)
 https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicBharat.m3u8
-#EXTINF:-1 tvg-id="TV9Bharatvarsh.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png" group-title="Hindi News",TV9 Bharatvarsh (720p)
+#EXTINF:-1 tvg-name="TV9 Bharatvarsh" tvg-chno="107" tvg-language="Hindi" tvg-id="TV9Bharatvarsh.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png" group-title="Hindi News",107 · TV9 Bharatvarsh (720p)
 https://dyjmyiv3bp2ez.cloudfront.net/pub-iotv9hinjzgtpe/liveabr/playlist.m3u8
-#EXTINF:-1 tvg-id="News18India.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",News18 India (1080p)
+#EXTINF:-1 tvg-name="News18 India" tvg-chno="108" tvg-language="Hindi" tvg-id="News18India.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",108 · News18 India (1080p)
 https://n18syndication.akamaized.net/bpk-tv/News18_India_NW18_MOB/output01/master.m3u8
-#EXTINF:-1 tvg-id="NewsNation.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png" group-title="Hindi News",News Nation (1080p)
+#EXTINF:-1 tvg-name="News Nation" tvg-chno="109" tvg-language="Hindi" tvg-id="NewsNation.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png" group-title="Hindi News",109 · News Nation (1080p)
 https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/6cd2f649739a45ca9de1daf81cc7d0f2/index.m3u8
-#EXTINF:-1 tvg-id="IndiaTV.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png" group-title="Hindi News",India TV (720p)
+#EXTINF:-1 tvg-name="India TV" tvg-chno="110" tvg-language="Hindi" tvg-id="IndiaTV.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png" group-title="Hindi News",110 · India TV (720p)
 https://pl-indiatvnews.akamaized.net/out/v1/db79179b608641ceaa5a4d0dd0dca8da/index.m3u8
-#EXTINF:-1 tvg-id="TimesNowNavbharat.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png" group-title="Hindi News",Times Now Navbharat (1080p)
+#EXTINF:-1 tvg-name="Times Now Navbharat" tvg-chno="111" tvg-language="Hindi" tvg-id="TimesNowNavbharat.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png" group-title="Hindi News",111 · Times Now Navbharat (1080p)
 https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/TimesNowNavbharat.m3u8
-#EXTINF:-1 tvg-id="BharatSamachar.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png" group-title="Hindi News",Bharat Samachar (576p)
+#EXTINF:-1 tvg-name="Bharat Samachar" tvg-chno="112" tvg-language="Hindi" tvg-id="BharatSamachar.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png" group-title="Hindi News",112 · Bharat Samachar (576p)
 https://trs1.aynaott.com/BharatSamachar/index.m3u8
-#EXTINF:-1 tvg-id="GoodNewsToday.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png" group-title="Hindi News",Good News Today (720p)
+#EXTINF:-1 tvg-name="Good News Today" tvg-chno="113" tvg-language="Hindi" tvg-id="GoodNewsToday.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png" group-title="Hindi News",113 · Good News Today (720p)
 https://aajtaklive.vgcdn.net/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/3196cced-ce29-4219-9809-f07ccdaa02b9/vglive-sk-848805/master.m3u8
-#EXTINF:-1 tvg-id="SudarshanNews.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png" group-title="Hindi News",Sudarshan News (1080p)
+#EXTINF:-1 tvg-name="Sudarshan News" tvg-chno="114" tvg-language="Hindi" tvg-id="SudarshanNews.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png" group-title="Hindi News",114 · Sudarshan News (1080p)
 https://ott.livelegitpro.in/sudarshannews/sudarshannews/tracks-v1/index.fmp4.m3u8
-#EXTINF:-1 tvg-id="News24.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540" group-title="Hindi News",News 24 (720p)
+#EXTINF:-1 tvg-name="News 24" tvg-chno="115" tvg-language="Hindi" tvg-id="News24.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540" group-title="Hindi News",115 · News 24 (720p)
 https://vidcdn.vidgyor.com/news24-origin/liveabr/playlist.m3u8
-#EXTINF:-1 tvg-id="SansadTV1.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png" group-title="Hindi News",Sansad TV 1 HD (1080p)
+#EXTINF:-1 tvg-name="Sansad TV" tvg-chno="116" tvg-language="Hindi" tvg-id="SansadTV1.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png" group-title="Hindi News",116 · Sansad TV (1080p)
 https://d2lk5u59tns74c.cloudfront.net/out/v1/fff8f20221d5456e8922e689d71dedc3/index.m3u8

--- a/iptv/hindi-news.m3u
+++ b/iptv/hindi-news.m3u
@@ -1,0 +1,34 @@
+#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"
+#PLAYLIST:Hindi News Channels
+#EXTINF:-1 tvg-id="AajTak.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_AAJ_TAK/images/LOGO_HD/image.png" group-title="Hindi News",Aaj Tak HD (1080p)
+https://feeds.intoday.in/aajtak/api/aajtakhd/master.m3u8
+#EXTINF:-1 tvg-id="ABPNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s158138_ld_h15_aa.png?lock=720x540" group-title="Hindi News",ABP News (1080p)
+https://d1rc86nwwc9fag.cloudfront.net/vglive-sk-472500/abpnews/master.m3u8
+#EXTINF:-1 tvg-id="NDTVIndia.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NDTV_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",NDTV India (720p)
+http://103.213.31.109:90/StarUtsavMovies/playlist.m3u8
+#EXTINF:-1 tvg-id="DDNews.in@HD" tvg-logo="https://ltsk-cdn.s3.eu-west-1.amazonaws.com/jumpstart/Temp_Live/cdn/HLS/Channel/transparentImages/DD%20News%20HD.png" group-title="Hindi News",DD News HD (1080p)
+https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/0811cd8c37ca4c409d5385a6cd2fa18b/index.m3u8
+#EXTINF:-1 tvg-id="ZeeNews.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/GNLZZGG0023VWYC.png?lock=720x540" group-title="Hindi News",Zee News (1080p)
+https://dknttpxmr0dwf.cloudfront.net/index_57.m3u8
+#EXTINF:-1 tvg-id="RepublicBharat.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s143724_ld_h15_aa.png?lock=720x540" group-title="Hindi News",Republic Bharat (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/RepublicBharat.m3u8
+#EXTINF:-1 tvg-id="TV9Bharatvarsh.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TV9_BHARATVARSH/images/LOGO_HD/image.png" group-title="Hindi News",TV9 Bharatvarsh (720p)
+https://dyjmyiv3bp2ez.cloudfront.net/pub-iotv9hinjzgtpe/liveabr/playlist.m3u8
+#EXTINF:-1 tvg-id="News18India.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS18_INDIA/images/LOGO_HD/image.png" group-title="Hindi News",News18 India (1080p)
+https://n18syndication.akamaized.net/bpk-tv/News18_India_NW18_MOB/output01/master.m3u8
+#EXTINF:-1 tvg-id="NewsNation.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_NEWS_NATION/images/LOGO_HD/image.png" group-title="Hindi News",News Nation (1080p)
+https://d3qs3d2rkhfqrt.cloudfront.net/out/v1/6cd2f649739a45ca9de1daf81cc7d0f2/index.m3u8
+#EXTINF:-1 tvg-id="IndiaTV.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_INDIA_TV/images/LOGO_HD/image.png" group-title="Hindi News",India TV (720p)
+https://pl-indiatvnews.akamaized.net/out/v1/db79179b608641ceaa5a4d0dd0dca8da/index.m3u8
+#EXTINF:-1 tvg-id="TimesNowNavbharat.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_TIMES_NOW_NAVBHARAT_HD/images/LOGO_HD/image.png" group-title="Hindi News",Times Now Navbharat (1080p)
+https://raw.githubusercontent.com/amazeyourself/adaptive-streams/refs/heads/main/streams/in/YuppTV/TimesNowNavbharat.m3u8
+#EXTINF:-1 tvg-id="BharatSamachar.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_BHARAT_SAMACHAR/images/LOGO_HD/image.png" group-title="Hindi News",Bharat Samachar (576p)
+https://trs1.aynaott.com/BharatSamachar/index.m3u8
+#EXTINF:-1 tvg-id="GoodNewsToday.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_GOOD_NEWS_TODAY/images/LOGO_HD/image.png" group-title="Hindi News",Good News Today (720p)
+https://aajtaklive.vgcdn.net/v1/master/611d79b11b77e2f571934fd80ca1413453772ac7/3196cced-ce29-4219-9809-f07ccdaa02b9/vglive-sk-848805/master.m3u8
+#EXTINF:-1 tvg-id="SudarshanNews.in@SD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SUDARSHAN_NEWS/images/LOGO_HD/image.png" group-title="Hindi News",Sudarshan News (1080p)
+https://ott.livelegitpro.in/sudarshannews/sudarshannews/tracks-v1/index.fmp4.m3u8
+#EXTINF:-1 tvg-id="News24.in@SD" tvg-logo="https://dtil.tmsimg.com/assets/s90009_ld_h15_aa.png?lock=720x540" group-title="Hindi News",News 24 (720p)
+https://vidcdn.vidgyor.com/news24-origin/liveabr/playlist.m3u8
+#EXTINF:-1 tvg-id="SansadTV1.in@HD" tvg-logo="https://xstreamcp-assets-msp.streamready.in/assets/LIVETV/LIVECHANNEL/LIVETV_LIVETVCHANNEL_SANSAD_TV_SYMHYP_1_HD/images/LOGO_HD/LOGO_HD_image.png" group-title="Hindi News",Sansad TV 1 HD (1080p)
+https://d2lk5u59tns74c.cloudfront.net/out/v1/fff8f20221d5456e8922e689d71dedc3/index.m3u8

--- a/requirements-drive.txt
+++ b/requirements-drive.txt
@@ -1,0 +1,3 @@
+google-api-python-client>=2.100.0
+google-auth-httplib2>=0.2.0
+google-auth-oauthlib>=1.2.0

--- a/scripts/build-playlists.py
+++ b/scripts/build-playlists.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """Build curated Hindi and English news M3U playlists from iptv-org sources."""
 
+from __future__ import annotations
+
+import json
 import re
 import sys
 import urllib.request
@@ -9,7 +12,6 @@ from pathlib import Path
 IPTV_ORG_HIN = "https://iptv-org.github.io/iptv/languages/hin.m3u"
 IPTV_ORG_ENG = "https://iptv-org.github.io/iptv/languages/eng.m3u"
 
-# Curated channels by tvg-id (preferred) with display name fallback patterns.
 HINDI_CHANNELS = [
     ("AajTak.in@HD", "Aaj Tak"),
     ("ABPNews.in@SD", "ABP News"),
@@ -54,6 +56,9 @@ ENGLISH_CHANNELS = [
     ("NHKWorldJapan.jp@SD", "NHK World"),
 ]
 
+HINDI_BASE = 101
+ENGLISH_BASE = 201
+
 
 def fetch_m3u(url: str) -> str:
     with urllib.request.urlopen(url, timeout=60) as response:
@@ -81,11 +86,13 @@ def parse_m3u(content: str) -> list[dict]:
         i += 1
 
         tvg_id_match = re.search(r'tvg-id="([^"]+)"', info)
+        logo_match = re.search(r'tvg-logo="([^"]+)"', info)
         channel_name = info.rsplit(",", 1)[-1] if "," in info else ""
         entries.append(
             {
                 "tvg_id": tvg_id_match.group(1) if tvg_id_match else "",
                 "name": channel_name,
+                "logo": logo_match.group(1) if logo_match else "",
                 "info": info,
                 "extras": extras,
                 "url": url,
@@ -104,12 +111,49 @@ def find_entry(entries: list[dict], tvg_id: str, label: str) -> dict | None:
     return None
 
 
-def build_playlist(title: str, group: str, channel_specs: list[tuple[str, str]], entries: list[dict]) -> str:
-    lines = [
-        '#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"',
-        f"#PLAYLIST:{title}",
-    ]
+def quality_suffix(name: str) -> str:
+    match = re.search(r"\((\d+p|Not 24/7|Geo-blocked)[^)]*\)", name, re.I)
+    return match.group(0) if match else ""
+
+
+def build_extinf(entry: dict, *, number: int, label: str, group: str, language: str) -> str:
+    suffix = quality_suffix(entry["name"])
+    flags = ""
+    if suffix:
+        flags = f" {suffix}"
+    display = f"{number:03d} · {label}{flags}"
+
+    info = entry["info"]
+    info = re.sub(r'tvg-chno="[^"]*"', "", info)
+    info = re.sub(r'group-title="[^"]*"', f'group-title="{group}"', info)
+    if 'tvg-language="' not in info:
+        info = info.replace("#EXTINF:-1", f'#EXTINF:-1 tvg-language="{language}"', 1)
+    else:
+        info = re.sub(r'tvg-language="[^"]*"', f'tvg-language="{language}"', info)
+
+    if 'tvg-chno="' not in info:
+        info = info.replace("#EXTINF:-1", f'#EXTINF:-1 tvg-chno="{number}"', 1)
+    else:
+        info = re.sub(r'tvg-chno="[^"]*"', f'tvg-chno="{number}"', info)
+
+    if 'tvg-name="' not in info:
+        info = info.replace("#EXTINF:-1", f'#EXTINF:-1 tvg-name="{label}"', 1)
+
+    info = re.sub(r",[^,]+$", f",{display}", info)
+    return info
+
+
+def collect_channels(
+    channel_specs: list[tuple[str, str]],
+    entries: list[dict],
+    *,
+    base_number: int,
+    group: str,
+    language: str,
+) -> list[dict]:
+    channels: list[dict] = []
     seen_urls: set[str] = set()
+    number = base_number
 
     for tvg_id, label in channel_specs:
         entry = find_entry(entries, tvg_id, label)
@@ -120,13 +164,69 @@ def build_playlist(title: str, group: str, channel_specs: list[tuple[str, str]],
             continue
         seen_urls.add(entry["url"])
 
-        info = re.sub(r'group-title="[^"]*"', f'group-title="{group}"', entry["info"])
-        lines.append(info)
-        lines.extend(entry["extras"])
-        lines.append(entry["url"])
-        print(f"  + {label}: {entry['name']}", file=sys.stderr)
+        extinf = build_extinf(entry, number=number, label=label, group=group, language=language)
+        channels.append(
+            {
+                "number": number,
+                "label": label,
+                "group": group,
+                "language": language,
+                "display": extinf.rsplit(",", 1)[-1],
+                "logo": entry["logo"],
+                "url": entry["url"],
+                "extinf": extinf,
+                "extras": entry["extras"],
+            }
+        )
+        print(f"  + {number:03d} {label}: {entry['name']}", file=sys.stderr)
+        number += 1
 
+    return channels
+
+
+def render_playlist(title: str, channels: list[dict], *, grouped: bool = False) -> str:
+    lines = [
+        '#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"',
+        f"#PLAYLIST:{title}",
+    ]
+    current_group = None
+    for channel in channels:
+        if grouped and channel["group"] != current_group:
+            current_group = channel["group"]
+            lines.append(f"#EXTGRP:{current_group}")
+        lines.append(channel["extinf"])
+        lines.extend(channel["extras"])
+        lines.append(channel["url"])
     return "\n".join(lines) + "\n"
+
+
+def write_channel_map(path: Path, hindi: list[dict], english: list[dict]) -> None:
+    lines = [
+        "NEWS TV — Channel Guide",
+        "=======================",
+        "",
+        "Hindi News (101–199)",
+        "--------------------",
+    ]
+    for ch in hindi:
+        lines.append(f"  {ch['number']:03d}  {ch['label']}")
+    lines.extend(["", "English News (201–299)", "----------------------"])
+    for ch in english:
+        lines.append(f"  {ch['number']:03d}  {ch['label']}")
+    lines.extend(
+        [
+            "",
+            "VLC shortcuts",
+            "-------------",
+            "  Ctrl+L     Open playlist sidebar",
+            "  PgUp/PgDn  Previous / next channel",
+            "  Up/Down    Fine channel step",
+            "  F          Fullscreen",
+            "",
+            "Launch: ./scripts/news-tv.sh",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def main() -> None:
@@ -137,28 +237,40 @@ def main() -> None:
     print("Fetching Hindi channels...", file=sys.stderr)
     hin_entries = parse_m3u(fetch_m3u(IPTV_ORG_HIN))
     print("Fetching English channels...", file=sys.stderr)
-
     eng_entries = parse_m3u(fetch_m3u(IPTV_ORG_ENG))
 
     print("\nHindi news:", file=sys.stderr)
-    hindi = build_playlist("Hindi News Channels", "Hindi News", HINDI_CHANNELS, hin_entries)
-
+    hindi = collect_channels(
+        HINDI_CHANNELS, hin_entries, base_number=HINDI_BASE, group="Hindi News", language="Hindi"
+    )
     print("\nEnglish news:", file=sys.stderr)
-    english = build_playlist("English News Channels", "English News", ENGLISH_CHANNELS, eng_entries)
+    english = collect_channels(
+        ENGLISH_CHANNELS, eng_entries, base_number=ENGLISH_BASE, group="English News", language="English"
+    )
 
-    (out_dir / "hindi-news.m3u").write_text(hindi, encoding="utf-8")
-    (out_dir / "english-news.m3u").write_text(english, encoding="utf-8")
+    (out_dir / "hindi-news.m3u").write_text(
+        render_playlist("Hindi News Channels", hindi), encoding="utf-8"
+    )
+    (out_dir / "english-news.m3u").write_text(
+        render_playlist("English News Channels", english), encoding="utf-8"
+    )
+    (out_dir / "all-news.m3u").write_text(
+        render_playlist("All News Channels", hindi + english, grouped=True), encoding="utf-8"
+    )
 
-    combined_lines = hindi.splitlines()[:2]
-    for block in (hindi, english):
-        for line in block.splitlines():
-            if line.startswith("#EXTINF") or line.startswith("#EXTVLCOPT") or (
-                line.startswith("http") and line.strip()
-            ):
-                if line not in combined_lines:
-                    combined_lines.append(line)
+    catalog = {
+        "hindi": [
+            {k: ch[k] for k in ("number", "label", "group", "language", "display", "logo", "url")}
+            for ch in hindi
+        ],
+        "english": [
+            {k: ch[k] for k in ("number", "label", "group", "language", "display", "logo", "url")}
+            for ch in english
+        ],
+    }
+    (out_dir / "channels.json").write_text(json.dumps(catalog, indent=2), encoding="utf-8")
+    write_channel_map(out_dir / "channel-guide.txt", hindi, english)
 
-    (out_dir / "all-news.m3u").write_text("\n".join(combined_lines) + "\n", encoding="utf-8")
     print(f"\nWrote playlists to {out_dir}", file=sys.stderr)
 
 

--- a/scripts/build-playlists.py
+++ b/scripts/build-playlists.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Build curated Hindi and English news M3U playlists from iptv-org sources."""
+
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+IPTV_ORG_HIN = "https://iptv-org.github.io/iptv/languages/hin.m3u"
+IPTV_ORG_ENG = "https://iptv-org.github.io/iptv/languages/eng.m3u"
+
+# Curated channels by tvg-id (preferred) with display name fallback patterns.
+HINDI_CHANNELS = [
+    ("AajTak.in@HD", "Aaj Tak"),
+    ("ABPNews.in@SD", "ABP News"),
+    ("NDTVIndia.in@SD", "NDTV India"),
+    ("DDNews.in@HD", "DD News"),
+    ("ZeeNews.in@SD", "Zee News"),
+    ("RepublicBharat.in@SD", "Republic Bharat"),
+    ("TV9Bharatvarsh.in@SD", "TV9 Bharatvarsh"),
+    ("News18India.in@SD", "News18 India"),
+    ("NewsNation.in@SD", "News Nation"),
+    ("IndiaTV.in@SD", "India TV"),
+    ("TimesNowNavbharat.in@SD", "Times Now Navbharat"),
+    ("BharatSamachar.in@SD", "Bharat Samachar"),
+    ("GoodNewsToday.in@SD", "Good News Today"),
+    ("SudarshanNews.in@SD", "Sudarshan News"),
+    ("News24.in@SD", "News 24"),
+    ("SansadTV1.in@HD", "Sansad TV"),
+]
+
+ENGLISH_CHANNELS = [
+    ("AlJazeera.qa@English", "Al Jazeera English"),
+    ("France24.fr@English", "France 24 English"),
+    ("DW.de@English", "DW English"),
+    ("BBCNews.uk@UK", "BBC News"),
+    ("BBCNews.uk@Europe", "BBC News"),
+    ("SkyNews.uk@SD", "Sky News"),
+    ("SkyNews.ie@SD", "Sky News"),
+    ("ReutersTV.us@SD", "Reuters"),
+    ("NDTV24x7.in@SD", "NDTV 24x7"),
+    ("ABCNews.au@Sydney", "ABC News Australia"),
+    ("CBSNews247.us@SD", "CBS News 24/7"),
+    ("FoxNewsChannel.us@SD", "Fox News"),
+    ("EuronewsEnglish.fr@SD", "Euronews English"),
+    ("CGTN.cn@SD", "CGTN"),
+    ("TRTWorld.tr@SD", "TRT World"),
+    ("WION.in@SD", "WION"),
+    ("TimesNow.in@SD", "Times Now"),
+    ("RepublicTV.in@SD", "Republic TV"),
+    ("MirrorNow.in@SD", "Mirror Now"),
+    ("BloombergTV.us@US", "Bloomberg TV"),
+    ("CNBCUK.uk@SD", "CNBC"),
+    ("NHKWorldJapan.jp@SD", "NHK World"),
+]
+
+
+def fetch_m3u(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=60) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def parse_m3u(content: str) -> list[dict]:
+    entries = []
+    lines = content.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.startswith("#EXTINF"):
+            i += 1
+            continue
+
+        info = line
+        extras = []
+        i += 1
+        while i < len(lines) and lines[i].startswith("#EXT"):
+            extras.append(lines[i])
+            i += 1
+
+        url = lines[i] if i < len(lines) and not lines[i].startswith("#") else ""
+        i += 1
+
+        tvg_id_match = re.search(r'tvg-id="([^"]+)"', info)
+        channel_name = info.rsplit(",", 1)[-1] if "," in info else ""
+        entries.append(
+            {
+                "tvg_id": tvg_id_match.group(1) if tvg_id_match else "",
+                "name": channel_name,
+                "info": info,
+                "extras": extras,
+                "url": url,
+            }
+        )
+    return entries
+
+
+def find_entry(entries: list[dict], tvg_id: str, label: str) -> dict | None:
+    for entry in entries:
+        if entry["tvg_id"] == tvg_id:
+            return entry
+    for entry in entries:
+        if label.lower() in entry["name"].lower() and "News" in entry["info"]:
+            return entry
+    return None
+
+
+def build_playlist(title: str, group: str, channel_specs: list[tuple[str, str]], entries: list[dict]) -> str:
+    lines = [
+        '#EXTM3U x-tvg-url="https://iptv-org.github.io/epg/guides.xml"',
+        f"#PLAYLIST:{title}",
+    ]
+    seen_urls: set[str] = set()
+
+    for tvg_id, label in channel_specs:
+        entry = find_entry(entries, tvg_id, label)
+        if not entry or not entry["url"]:
+            print(f"  - missing: {label} ({tvg_id})", file=sys.stderr)
+            continue
+        if entry["url"] in seen_urls:
+            continue
+        seen_urls.add(entry["url"])
+
+        info = re.sub(r'group-title="[^"]*"', f'group-title="{group}"', entry["info"])
+        lines.append(info)
+        lines.extend(entry["extras"])
+        lines.append(entry["url"])
+        print(f"  + {label}: {entry['name']}", file=sys.stderr)
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    out_dir = root / "iptv"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print("Fetching Hindi channels...", file=sys.stderr)
+    hin_entries = parse_m3u(fetch_m3u(IPTV_ORG_HIN))
+    print("Fetching English channels...", file=sys.stderr)
+
+    eng_entries = parse_m3u(fetch_m3u(IPTV_ORG_ENG))
+
+    print("\nHindi news:", file=sys.stderr)
+    hindi = build_playlist("Hindi News Channels", "Hindi News", HINDI_CHANNELS, hin_entries)
+
+    print("\nEnglish news:", file=sys.stderr)
+    english = build_playlist("English News Channels", "English News", ENGLISH_CHANNELS, eng_entries)
+
+    (out_dir / "hindi-news.m3u").write_text(hindi, encoding="utf-8")
+    (out_dir / "english-news.m3u").write_text(english, encoding="utf-8")
+
+    combined_lines = hindi.splitlines()[:2]
+    for block in (hindi, english):
+        for line in block.splitlines():
+            if line.startswith("#EXTINF") or line.startswith("#EXTVLCOPT") or (
+                line.startswith("http") and line.strip()
+            ):
+                if line not in combined_lines:
+                    combined_lines.append(line)
+
+    (out_dir / "all-news.m3u").write_text("\n".join(combined_lines) + "\n", encoding="utf-8")
+    print(f"\nWrote playlists to {out_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/channel-data.py
+++ b/scripts/channel-data.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Parse IPTV playlists into a channel catalog for navigation tools."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+IPTV_DIR = ROOT / "iptv"
+CATALOG = IPTV_DIR / "channels.json"
+
+
+def load_catalog() -> dict:
+    if CATALOG.exists():
+        return json.loads(CATALOG.read_text(encoding="utf-8"))
+
+    channels: dict[str, list[dict]] = {"hindi": [], "english": []}
+    for lang, playlist in (("hindi", "hindi-news.m3u"), ("english", "english-news.m3u")):
+        path = IPTV_DIR / playlist
+        if not path.exists():
+            continue
+        lines = path.read_text(encoding="utf-8").splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if not line.startswith("#EXTINF"):
+                i += 1
+                continue
+            display = line.rsplit(",", 1)[-1]
+            number_match = re.search(r"^(\d{3})", display)
+            label_match = re.search(r"·\s*(.+?)(?:\s*\(|$)", display)
+            logo_match = re.search(r'tvg-logo="([^"]+)"', line)
+            group_match = re.search(r'group-title="([^"]+)"', line)
+            i += 1
+            while i < len(lines) and lines[i].startswith("#"):
+                i += 1
+            url = lines[i] if i < len(lines) else ""
+            i += 1
+            channels[lang].append(
+                {
+                    "number": int(number_match.group(1)) if number_match else 0,
+                    "label": label_match.group(1).strip() if label_match else display,
+                    "display": display,
+                    "logo": logo_match.group(1) if logo_match else "",
+                    "group": group_match.group(1) if group_match else lang.title(),
+                    "language": "Hindi" if lang == "hindi" else "English",
+                    "url": url,
+                }
+            )
+    return channels
+
+
+def all_channels(catalog: dict, language: str = "all") -> list[dict]:
+    if language == "hindi":
+        return catalog.get("hindi", [])
+    if language == "english":
+        return catalog.get("english", [])
+    return catalog.get("hindi", []) + catalog.get("english", [])
+
+
+def find_channel(catalog: dict, query: str, language: str = "all") -> dict | None:
+    query = query.strip()
+    if not query:
+        return None
+
+    pool = all_channels(catalog, language)
+    if query.isdigit():
+        number = int(query)
+        for channel in pool:
+            if channel["number"] == number:
+                return channel
+        return None
+
+    lowered = query.lower()
+    matches = [ch for ch in pool if lowered in ch["label"].lower()]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        return matches[0]
+    return None
+
+
+def playlist_path(language: str) -> Path:
+    mapping = {
+        "hindi": IPTV_DIR / "hindi-news.m3u",
+        "english": IPTV_DIR / "english-news.m3u",
+        "all": IPTV_DIR / "all-news.m3u",
+    }
+    return mapping[language]
+
+
+def write_start_playlist(selected: dict, language: str) -> Path:
+    """Write a temp playlist with the selected channel first for easy zapping."""
+    source = playlist_path(language)
+    lines = source.read_text(encoding="utf-8").splitlines()
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in lines:
+        if line.startswith("#EXTINF"):
+            if current:
+                blocks.append(current)
+            current = [line]
+        elif current:
+            current.append(line)
+    if current:
+        blocks.append(current)
+
+    selected_block = None
+    other_blocks: list[list[str]] = []
+    for block in blocks:
+        if block and block[0].startswith("#EXTINF") and selected["url"] in block:
+            selected_block = block
+        else:
+            other_blocks.append(block)
+
+    if not selected_block:
+        selected_block = [selected["extinf"]] if "extinf" in selected else []
+        if selected.get("url"):
+            selected_block.append(selected["url"])
+
+    header = [line for line in lines[:2] if line.startswith("#")]
+    output_lines = header[:]
+    if language == "all":
+        output_lines.append(f"#EXTGRP:{selected['group']}")
+    output_lines.extend(selected_block)
+    for block in other_blocks:
+        output_lines.extend(block)
+
+    temp = IPTV_DIR / ".start-channel.m3u"
+    temp.write_text("\n".join(output_lines) + "\n", encoding="utf-8")
+    return temp
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(json.dumps(load_catalog(), indent=2))
+    elif sys.argv[1] == "find":
+        catalog = load_catalog()
+        channel = find_channel(catalog, sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "all")
+        print(json.dumps(channel or {}, indent=2))
+    else:
+        print("Usage: channel-data.py [find <query> [language]]", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/news-tv.sh
+++ b/scripts/news-tv.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# Interactive news channel navigator for VLC — pick by number, name, or language.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IPTV_DIR="$REPO_ROOT/iptv"
+CATALOG="$IPTV_DIR/channels.json"
+PYTHON="${PYTHON:-python3}"
+
+BOLD='\033[1m'
+DIM='\033[2m'
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RESET='\033[0m'
+
+usage() {
+  cat <<'EOF'
+Usage: news-tv.sh [options]
+
+Interactive news channel navigator for VLC.
+
+Options:
+  --lang hindi|english|all   Filter channels by language
+  --channel N                Jump directly to channel number (101+)
+  --search TEXT              Search channel by name
+  --list                     Print channel guide and exit
+  --help                     Show this help
+
+With no options, opens an interactive menu.
+
+VLC controls once playing:
+  Ctrl+L       Playlist sidebar (grouped by language)
+  PgUp / PgDn  Previous / next channel
+  F            Fullscreen
+EOF
+}
+
+ensure_catalog() {
+  if [[ ! -f "$CATALOG" ]]; then
+    echo "Building channel catalog..."
+    "$PYTHON" "$SCRIPT_DIR/build-playlists.py"
+  fi
+}
+
+pick_vlc() {
+  if command -v vlc >/dev/null 2>&1; then
+    echo "vlc"
+  elif command -v cvlc >/dev/null 2>&1; then
+    echo "cvlc"
+  else
+    echo "VLC is not installed." >&2
+    exit 1
+  fi
+}
+
+print_header() {
+  printf '\n%s╔══════════════════════════════════════════╗%s\n' "$CYAN" "$RESET"
+  printf '%s║%s  %s📺  NEWS TV%s — Channel Navigator        %s║%s\n' "$CYAN" "$RESET" "$BOLD" "$RESET" "$CYAN" "$RESET"
+  printf '%s╚══════════════════════════════════════════╝%s\n\n' "$CYAN" "$RESET"
+}
+
+print_channels() {
+  local lang="$1"
+  "$PYTHON" - "$lang" "$CATALOG" <<'PY'
+import json, sys
+from pathlib import Path
+
+catalog = json.loads(Path(sys.argv[2]).read_text())
+lang = sys.argv[1]
+groups = []
+if lang in ("all", "hindi"):
+    groups.append(("Hindi News", catalog.get("hindi", [])))
+if lang in ("all", "english"):
+    groups.append(("English News", catalog.get("english", [])))
+
+for title, channels in groups:
+    print(f"\n{title}")
+    print("-" * len(title))
+    for ch in channels:
+        print(f"  {ch['number']:03d}  {ch['label']}")
+PY
+}
+
+search_channels() {
+  local lang="$1"
+  local query="$2"
+  "$PYTHON" - "$lang" "$query" <<'PY'
+import json, sys
+from pathlib import Path
+
+catalog = json.loads(Path(sys.argv[2]).read_text())
+lang, query = sys.argv[1], sys.argv[3].lower()
+pool = []
+if lang in ("all", "hindi"):
+    pool.extend(catalog.get("hindi", []))
+if lang in ("all", "english"):
+    pool.extend(catalog.get("english", []))
+
+matches = [ch for ch in pool if query in ch["label"].lower()]
+for ch in matches:
+    print(f"{ch['number']}\t{ch['label']}\t{ch['language']}")
+PY
+"$CATALOG"
+}
+
+resolve_channel() {
+  local lang="$1"
+  local query="$2"
+  "$PYTHON" - "$lang" "$query" "$CATALOG" <<'PY'
+import json, sys
+from pathlib import Path
+
+catalog = json.loads(Path(sys.argv[3]).read_text())
+lang, query = sys.argv[1], sys.argv[2].strip()
+pool = []
+if lang in ("all", "hindi"):
+    pool.extend(catalog.get("hindi", []))
+if lang in ("all", "english"):
+    pool.extend(catalog.get("english", []))
+
+if query.isdigit():
+    number = int(query)
+    for ch in pool:
+        if ch["number"] == number:
+            print(json.dumps(ch))
+            sys.exit(0)
+    sys.exit(1)
+
+q = query.lower()
+matches = [ch for ch in pool if q in ch["label"].lower()]
+if len(matches) == 1:
+    print(json.dumps(matches[0]))
+elif len(matches) > 1:
+    print(json.dumps({"ambiguous": [m["number"] for m in matches], "matches": matches}))
+else:
+    sys.exit(1)
+PY
+}
+
+launch_vlc() {
+  local lang="$1"
+  local channel_json="$2"
+  local vlc playlist temp
+  vlc="$(pick_vlc)"
+
+  case "$lang" in
+    hindi) playlist="$IPTV_DIR/hindi-news.m3u" ;;
+    english) playlist="$IPTV_DIR/english-news.m3u" ;;
+    all) playlist="$IPTV_DIR/all-news.m3u" ;;
+  esac
+
+  temp="$("$PYTHON" - "$playlist" "$channel_json" <<'PY'
+import json, sys
+from pathlib import Path
+
+playlist_path = Path(sys.argv[1])
+channel = json.loads(sys.argv[2])
+lines = playlist_path.read_text(encoding="utf-8").splitlines()
+
+blocks = []
+current = []
+for line in lines:
+    if line.startswith("#EXTINF"):
+        if current:
+            blocks.append(current)
+        current = [line]
+    elif current:
+        current.append(line)
+if current:
+    blocks.append(current)
+
+selected = None
+others = []
+for block in blocks:
+    if channel["url"] in block:
+        selected = block
+    else:
+        others.append(block)
+
+header = [line for line in lines if line.startswith("#EXTM3U") or line.startswith("#PLAYLIST")]
+out = header[:]
+if any(line.startswith("#EXTGRP") for line in lines):
+    out.append(f"#EXTGRP:{channel['group']}")
+if selected:
+    out.extend(selected)
+for block in others:
+    out.extend(block)
+
+temp = playlist_path.parent / ".start-channel.m3u"
+temp.write_text("\n".join(out) + "\n", encoding="utf-8")
+print(temp)
+PY
+)"
+
+  local label number
+  label="$(echo "$channel_json" | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["label"])')"
+  number="$(echo "$channel_json" | "$PYTHON" -c 'import json,sys; print(json.load(sys.stdin)["number"])')"
+
+  printf '\n%s▶ Starting channel %03d · %s%s\n' "$GREEN" "$number" "$label" "$RESET"
+  printf '%s  Playlist tree enabled — use Ctrl+L to browse groups%s\n\n' "$DIM" "$RESET"
+
+  exec "$vlc" \
+    --playlist-autostart \
+    --playlist-tree \
+    "$temp"
+}
+
+pick_language() {
+  print_header
+  echo "Choose a language pack:"
+  echo
+  echo "  1) Hindi news   (channels 101–116)"
+  echo "  2) English news (channels 201–220)"
+  echo "  3) All news     (both groups)"
+  echo "  q) Quit"
+  echo
+  read -r -p "Selection [1-3]: " choice
+  case "$choice" in
+    1) echo "hindi" ;;
+    2) echo "english" ;;
+    3) echo "all" ;;
+    q|Q) exit 0 ;;
+    *) echo "Invalid choice." >&2; pick_language ;;
+  esac
+}
+
+interactive_loop() {
+  local lang="$1"
+  while true; do
+    print_header
+    echo "Language pack: ${lang}"
+    echo
+    print_channels "$lang"
+    echo
+    echo "Enter a channel number (e.g. 101 or 205), part of a name, or:"
+    echo "  /hindi   /english   /all   — switch language pack"
+    echo "  list     — show guide again"
+    echo "  help     — VLC keyboard shortcuts"
+    echo "  q        — quit"
+    echo
+    read -r -p "Channel › " input || exit 0
+    input="$(echo "$input" | xargs)"
+    [[ -z "$input" ]] && continue
+
+    case "$input" in
+      q|Q) exit 0 ;;
+      list) continue ;;
+      help|h)
+        cat <<'HELP'
+
+VLC shortcuts:
+  Ctrl+L       Open playlist sidebar (channels grouped by language)
+  PgUp / PgDn  Previous / next channel
+  Up / Down    Step through playlist
+  F            Fullscreen
+  Space        Pause / play
+
+HELP
+        read -r -p "Press Enter to continue..."
+        continue
+        ;;
+      /hindi) lang="hindi"; continue ;;
+      /english) lang="english"; continue ;;
+      /all) lang="all"; continue ;;
+    esac
+
+    local result
+    if ! result="$(resolve_channel "$lang" "$input" 2>/dev/null)"; then
+      echo
+      echo "No channel matched '$input'. Try a number (101, 205) or name (aaj, bbc)."
+      read -r -p "Press Enter to continue..."
+      continue
+    fi
+
+    if echo "$result" | "$PYTHON" -c 'import json,sys; d=json.load(sys.stdin); sys.exit(0 if "ambiguous" not in d else 1)' 2>/dev/null; then
+      launch_vlc "$lang" "$result"
+    fi
+
+    echo
+    echo "Multiple matches:"
+    echo "$result" | "$PYTHON" -c '
+import json, sys
+data = json.load(sys.stdin)
+for ch in data["matches"]:
+    print(f"  {ch[\"number\"]:03d}  {ch[\"label\"]} ({ch[\"language\"]})")
+'
+    read -r -p "Enter exact channel number: " exact || exit 0
+    if result="$(resolve_channel "$lang" "$exact" 2>/dev/null)"; then
+      launch_vlc "$lang" "$result"
+    fi
+  done
+}
+
+main() {
+  ensure_catalog
+
+  local lang=""
+  local query=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --lang) shift; lang="${1:-}" ;;
+      --channel|--search) shift; query="${1:-}" ;;
+      --list)
+        print_header
+        print_channels all
+        exit 0
+        ;;
+      --help|-h) usage; exit 0 ;;
+      *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    esac
+    shift
+  done
+
+  if [[ -n "$query" ]]; then
+    lang="${lang:-all}"
+    local result
+    result="$(resolve_channel "$lang" "$query")" || {
+      echo "Channel not found: $query" >&2
+      exit 1
+    }
+    launch_vlc "$lang" "$result"
+  fi
+
+  if [[ -z "$lang" ]]; then
+    lang="$(pick_language)"
+  fi
+
+  interactive_loop "$lang"
+}
+
+main "$@"

--- a/scripts/upload-to-drive.py
+++ b/scripts/upload-to-drive.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Upload IPTV M3U playlists to Google Drive.
+
+Authentication options (pick one):
+
+1. Service account (best for automation)
+   - Create a service account in Google Cloud Console
+   - Download the JSON key to e.g. credentials/service-account.json
+   - Share your Drive folder with the service account email
+   - export GOOGLE_APPLICATION_CREDENTIALS=credentials/service-account.json
+   - export GOOGLE_DRIVE_FOLDER_ID=<folder_id_from_drive_url>
+
+2. OAuth user account (interactive, one-time browser sign-in)
+   - Create an OAuth Desktop client in Google Cloud Console
+   - Download client_secret JSON to credentials/oauth-client.json
+   - export GOOGLE_OAUTH_CLIENT_SECRET=credentials/oauth-client.json
+   - export GOOGLE_DRIVE_FOLDER_ID=<optional_folder_id>
+   - Run this script; complete sign-in in the browser when prompted
+"""
+
+from __future__ import annotations
+
+import argparse
+import mimetypes
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+IPTV_DIR = ROOT / "iptv"
+DEFAULT_FILES = [
+    IPTV_DIR / "hindi-news.m3u",
+    IPTV_DIR / "english-news.m3u",
+    IPTV_DIR / "all-news.m3u",
+    IPTV_DIR / "channel-guide.txt",
+]
+TOKEN_PATH = Path(os.environ.get("GOOGLE_DRIVE_TOKEN_PATH", ROOT / "credentials" / "drive-token.json"))
+OAUTH_CLIENT = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", str(ROOT / "credentials" / "oauth-client.json"))
+SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+
+
+def get_drive_service():
+    from google.oauth2 import service_account
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    from googleapiclient.discovery import build
+
+    service_account_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if service_account_path and Path(service_account_path).exists():
+        creds = service_account.Credentials.from_service_account_file(
+            service_account_path, scopes=SCOPES
+        )
+        return build("drive", "v3", credentials=creds, cache_discovery=False)
+
+    if not Path(OAUTH_CLIENT).exists():
+        print(
+            "Google Drive credentials not found.\n\n"
+            "Set up one of the following:\n"
+            "  1. GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json\n"
+            "  2. GOOGLE_OAUTH_CLIENT_SECRET=/path/to/oauth-client.json (then sign in)\n\n"
+            "Also set GOOGLE_DRIVE_FOLDER_ID to upload into a specific folder.\n"
+            "See scripts/upload-to-drive.py header for full setup steps.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    creds = None
+    if TOKEN_PATH.exists():
+        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
+
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(OAUTH_CLIENT, SCOPES)
+            creds = flow.run_local_server(port=0)
+        TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        TOKEN_PATH.write_text(creds.to_json(), encoding="utf-8")
+
+    return build("drive", "v3", credentials=creds, cache_discovery=False)
+
+
+def upload_file(service, path: Path, folder_id: str | None) -> dict:
+    from googleapiclient.http import MediaFileUpload
+
+    mime, _ = mimetypes.guess_type(path.name)
+    mime = mime or "application/octet-stream"
+    metadata: dict = {"name": path.name}
+    if folder_id:
+        metadata["parents"] = [folder_id]
+
+    media = MediaFileUpload(str(path), mimetype=mime, resumable=True)
+    result = (
+        service.files()
+        .create(body=metadata, media_body=media, fields="id,name,webViewLink,webContentLink")
+        .execute()
+    )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Upload IPTV playlists to Google Drive")
+    parser.add_argument(
+        "files",
+        nargs="*",
+        type=Path,
+        help="Files to upload (defaults to all M3U playlists)",
+    )
+    parser.add_argument(
+        "--folder-id",
+        default=os.environ.get("GOOGLE_DRIVE_FOLDER_ID"),
+        help="Google Drive folder ID (or set GOOGLE_DRIVE_FOLDER_ID)",
+    )
+    args = parser.parse_args()
+
+    files = args.files or DEFAULT_FILES
+    missing = [f for f in files if not f.exists()]
+    if missing:
+        for path in missing:
+            print(f"Missing file: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    service = get_drive_service()
+    uploaded = []
+    for path in files:
+        print(f"Uploading {path.name}...")
+        info = upload_file(service, path, args.folder_id)
+        uploaded.append(info)
+        print(f"  id:   {info.get('id')}")
+        print(f"  link: {info.get('webViewLink')}")
+
+    print(f"\nUploaded {len(uploaded)} file(s) to Google Drive.")
+    if args.folder_id:
+        print(f"Folder: https://drive.google.com/drive/folders/{args.folder_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/watch-news.sh
+++ b/scripts/watch-news.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Launch VLC with IPTV news playlists for an IPTV-like channel browsing experience.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IPTV_DIR="$REPO_ROOT/iptv"
+
+usage() {
+  cat <<'EOF'
+Usage: watch-news.sh [english|hindi|all] [--channel N]
+
+Open curated news channel playlists in VLC.
+
+  english   English news channels (default)
+  hindi     Hindi news channels
+  all       Combined English + Hindi playlist
+
+Options:
+  --channel N   Start on channel number N (1-based)
+  --list        Print available playlists and exit
+  --help        Show this help
+
+Examples:
+  ./scripts/watch-news.sh
+  ./scripts/watch-news.sh hindi
+  ./scripts/watch-news.sh all --channel 3
+EOF
+}
+
+pick_vlc() {
+  if command -v cvlc >/dev/null 2>&1; then
+    echo "cvlc"
+  elif command -v vlc >/dev/null 2>&1; then
+    echo "vlc"
+  else
+    echo "VLC is not installed. Install it with:" >&2
+    echo "  Ubuntu/Debian: sudo apt install vlc" >&2
+    echo "  macOS:         brew install --cask vlc" >&2
+    echo "  Windows:       https://www.videolan.org/vlc/" >&2
+    exit 1
+  fi
+}
+
+playlist_for() {
+  case "$1" in
+    english) echo "$IPTV_DIR/english-news.m3u" ;;
+    hindi) echo "$IPTV_DIR/hindi-news.m3u" ;;
+    all) echo "$IPTV_DIR/all-news.m3u" ;;
+    *) echo "Unknown playlist: $1" >&2; usage; exit 1 ;;
+  esac
+}
+
+list_channels() {
+  local playlist="$1"
+  local n=0
+  while IFS= read -r line; do
+    if [[ "$line" == \#EXTINF* ]]; then
+      n=$((n + 1))
+      name="${line##*,}"
+      printf "%3d. %s\n" "$n" "$name"
+    fi
+  done < "$playlist"
+}
+
+main() {
+  local lang="english"
+  local channel=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      english|hindi|all) lang="$1" ;;
+      --channel) shift; channel="${1:-}" ;;
+      --list)
+        for kind in english hindi all; do
+          local_file="$(playlist_for "$kind")"
+          echo "== $kind ($local_file) =="
+          list_channels "$local_file"
+          echo
+        done
+        exit 0
+        ;;
+      --help|-h) usage; exit 0 ;;
+      *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+    shift
+  done
+
+  local playlist
+  playlist="$(playlist_for "$lang")"
+  if [[ ! -f "$playlist" ]]; then
+    echo "Playlist not found: $playlist" >&2
+    echo "Run: python3 scripts/build-playlists.py" >&2
+    exit 1
+  fi
+
+  local vlc
+  vlc="$(pick_vlc)"
+
+  echo "Opening $lang news playlist in VLC..."
+  echo "Playlist: $playlist"
+  echo
+  echo "IPTV tips in VLC:"
+  echo "  - View > Playlist (Ctrl+L) to browse channels"
+  echo "  - Use Up/Down or PgUp/PgDn to change channels"
+  echo "  - Channels are grouped under 'English News' / 'Hindi News'"
+  echo
+
+  if [[ -n "$channel" ]]; then
+    local url
+    url="$(awk -v n="$channel" '
+      /^#EXTINF/ { idx++ }
+      idx == n && /^https?:/ { print; exit }
+    ' "$playlist")"
+    if [[ -z "$url" ]]; then
+      echo "Channel $channel not found in playlist." >&2
+      exit 1
+    fi
+    exec "$vlc" "$url"
+  fi
+
+  exec "$vlc" "$playlist"
+}
+
+main "$@"

--- a/scripts/watch-news.sh
+++ b/scripts/watch-news.sh
@@ -1,125 +1,21 @@
 #!/usr/bin/env bash
-# Launch VLC with IPTV news playlists for an IPTV-like channel browsing experience.
+# Launch VLC with IPTV news playlists. Defaults to the interactive navigator.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-IPTV_DIR="$REPO_ROOT/iptv"
 
-usage() {
-  cat <<'EOF'
-Usage: watch-news.sh [english|hindi|all] [--channel N]
+if [[ $# -eq 0 ]]; then
+  exec "$SCRIPT_DIR/news-tv.sh"
+fi
 
-Open curated news channel playlists in VLC.
-
-  english   English news channels (default)
-  hindi     Hindi news channels
-  all       Combined English + Hindi playlist
-
-Options:
-  --channel N   Start on channel number N (1-based)
-  --list        Print available playlists and exit
-  --help        Show this help
-
-Examples:
-  ./scripts/watch-news.sh
-  ./scripts/watch-news.sh hindi
-  ./scripts/watch-news.sh all --channel 3
-EOF
-}
-
-pick_vlc() {
-  if command -v cvlc >/dev/null 2>&1; then
-    echo "cvlc"
-  elif command -v vlc >/dev/null 2>&1; then
-    echo "vlc"
-  else
-    echo "VLC is not installed. Install it with:" >&2
-    echo "  Ubuntu/Debian: sudo apt install vlc" >&2
-    echo "  macOS:         brew install --cask vlc" >&2
-    echo "  Windows:       https://www.videolan.org/vlc/" >&2
-    exit 1
-  fi
-}
-
-playlist_for() {
-  case "$1" in
-    english) echo "$IPTV_DIR/english-news.m3u" ;;
-    hindi) echo "$IPTV_DIR/hindi-news.m3u" ;;
-    all) echo "$IPTV_DIR/all-news.m3u" ;;
-    *) echo "Unknown playlist: $1" >&2; usage; exit 1 ;;
-  esac
-}
-
-list_channels() {
-  local playlist="$1"
-  local n=0
-  while IFS= read -r line; do
-    if [[ "$line" == \#EXTINF* ]]; then
-      n=$((n + 1))
-      name="${line##*,}"
-      printf "%3d. %s\n" "$n" "$name"
-    fi
-  done < "$playlist"
-}
-
-main() {
-  local lang="english"
-  local channel=""
-
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      english|hindi|all) lang="$1" ;;
-      --channel) shift; channel="${1:-}" ;;
-      --list)
-        for kind in english hindi all; do
-          local_file="$(playlist_for "$kind")"
-          echo "== $kind ($local_file) =="
-          list_channels "$local_file"
-          echo
-        done
-        exit 0
-        ;;
-      --help|-h) usage; exit 0 ;;
-      *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
-    esac
+case "${1:-}" in
+  --interactive|-i)
     shift
-  done
+    exec "$SCRIPT_DIR/news-tv.sh" "$@"
+    ;;
+  --help|-h)
+    exec "$SCRIPT_DIR/news-tv.sh" --help
+    ;;
+esac
 
-  local playlist
-  playlist="$(playlist_for "$lang")"
-  if [[ ! -f "$playlist" ]]; then
-    echo "Playlist not found: $playlist" >&2
-    echo "Run: python3 scripts/build-playlists.py" >&2
-    exit 1
-  fi
-
-  local vlc
-  vlc="$(pick_vlc)"
-
-  echo "Opening $lang news playlist in VLC..."
-  echo "Playlist: $playlist"
-  echo
-  echo "IPTV tips in VLC:"
-  echo "  - View > Playlist (Ctrl+L) to browse channels"
-  echo "  - Use Up/Down or PgUp/PgDn to change channels"
-  echo "  - Channels are grouped under 'English News' / 'Hindi News'"
-  echo
-
-  if [[ -n "$channel" ]]; then
-    local url
-    url="$(awk -v n="$channel" '
-      /^#EXTINF/ { idx++ }
-      idx == n && /^https?:/ { print; exit }
-    ' "$playlist")"
-    if [[ -z "$url" ]]; then
-      echo "Channel $channel not found in playlist." >&2
-      exit 1
-    fi
-    exec "$vlc" "$url"
-  fi
-
-  exec "$vlc" "$playlist"
-}
-
-main "$@"
+exec "$SCRIPT_DIR/news-tv.sh" "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds intuitive navigation for VLC news playlists: numbered channels, grouped playlists, interactive terminal navigator, and a searchable web guide.

## Navigation tools

- **`./scripts/news-tv.sh`** — Interactive menu: pick Hindi/English/All, tune by number (101, 205) or name (bbc, aaj)
- **`guide.html`** — Searchable channel grid with VLC launch links
- **`iptv/channel-guide.txt`** — Quick-reference channel map

## Channel numbering

| Range | Language |
|-------|----------|
| 101–116 | Hindi news |
| 201–220 | English news |

## VLC shortcuts

- `Ctrl+L` — Playlist sidebar (grouped by language)
- `PgUp/PgDn` — Previous / next channel
- `F` — Fullscreen

## Usage

```bash
./scripts/news-tv.sh
./scripts/news-tv.sh --lang hindi --channel 101
./scripts/news-tv.sh --search bbc
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f49af-9dea-78d6-985b-834da5f75ab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f49af-9dea-78d6-985b-834da5f75ab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

